### PR TITLE
feat: Phase 2 - Data Layer (Dataset Loaders & Validation)

### DIFF
--- a/openagent_eval/datasets/__init__.py
+++ b/openagent_eval/datasets/__init__.py
@@ -1,0 +1,35 @@
+"""Dataset loading and validation module.
+
+This module provides dataset loaders for various formats (JSON, JSONL, CSV, HuggingFace)
+and data models for validation.
+
+Usage:
+    ```python
+    from openagent_eval.datasets import JSONDatasetLoader, Dataset
+
+    loader = JSONDatasetLoader()
+    dataset = loader.load(Path("data/questions.json"))
+    ```
+"""
+
+from openagent_eval.datasets.base import BaseDatasetLoader, Dataset, DatasetItem
+from openagent_eval.datasets.csv_loader import CSVDatasetLoader
+from openagent_eval.datasets.hf_loader import HFDatasetLoader
+from openagent_eval.datasets.json_loader import JSONDatasetLoader
+from openagent_eval.datasets.jsonl_loader import JSONLDatasetLoader
+from openagent_eval.datasets.models import DatasetItemModel, DatasetModel
+
+__all__ = [
+    # Core types
+    "BaseDatasetLoader",
+    "Dataset",
+    "DatasetItem",
+    # Pydantic models
+    "DatasetItemModel",
+    "DatasetModel",
+    # Loaders
+    "JSONDatasetLoader",
+    "JSONLDatasetLoader",
+    "CSVDatasetLoader",
+    "HFDatasetLoader",
+]

--- a/openagent_eval/datasets/base.py
+++ b/openagent_eval/datasets/base.py
@@ -1,0 +1,190 @@
+"""Base dataset loader interface and core data models.
+
+This module defines the abstract interface that all dataset loaders must implement,
+along with the core Dataset and DatasetItem data models used throughout the framework.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class DatasetItem:
+    """A single item in an evaluation dataset.
+
+    Attributes:
+        question: The question to evaluate.
+        ground_truth: The expected correct answer (optional).
+        context: The context provided to the RAG system (optional).
+        metadata: Additional metadata about this item.
+        contexts: List of retrieved contexts (populated after retrieval).
+    """
+
+    question: str
+    ground_truth: str | None = None
+    context: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    contexts: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary format.
+
+        Returns:
+            Dictionary representation of the dataset item.
+        """
+        result: dict[str, Any] = {"question": self.question}
+        if self.ground_truth is not None:
+            result["ground_truth"] = self.ground_truth
+        if self.context is not None:
+            result["context"] = self.context
+        if self.contexts:
+            result["contexts"] = self.contexts
+        if self.metadata:
+            result["metadata"] = self.metadata
+        return result
+
+
+@dataclass
+class Dataset:
+    """A collection of dataset items for evaluation.
+
+    Attributes:
+        items: List of dataset items.
+        name: Optional name for the dataset.
+        metadata: Dataset-level metadata.
+    """
+
+    items: list[DatasetItem] = field(default_factory=list)
+    name: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def size(self) -> int:
+        """Return the number of items in the dataset."""
+        return len(self.items)
+
+    @property
+    def has_ground_truth(self) -> bool:
+        """Check if all items have ground truth answers."""
+        return all(item.ground_truth is not None for item in self.items)
+
+    @property
+    def questions(self) -> list[str]:
+        """Return all questions in the dataset."""
+        return [item.question for item in self.items]
+
+    def __len__(self) -> int:
+        return len(self.items)
+
+    def __iter__(self):
+        return iter(self.items)
+
+    def __getitem__(self, index: int) -> DatasetItem:
+        return self.items[index]
+
+    def filter(
+        self,
+        predicate: Any | None = None,
+    ) -> Dataset:
+        """Filter dataset items based on a predicate.
+
+        Args:
+            predicate: Function that takes a DatasetItem and returns bool.
+
+        Returns:
+            New Dataset with filtered items.
+        """
+        if predicate is None:
+            return Dataset(items=list(self.items), name=self.name, metadata=self.metadata)
+        filtered = [item for item in self.items if predicate(item)]
+        return Dataset(
+            items=filtered,
+            name=self.name,
+            metadata=self.metadata,
+        )
+
+    def to_dicts(self) -> list[dict[str, Any]]:
+        """Convert all items to dictionary format.
+
+        Returns:
+            List of dictionary representations.
+        """
+        return [item.to_dict() for item in self.items]
+
+
+class BaseDatasetLoader(ABC):
+    """Abstract base class for dataset loaders.
+
+    All dataset loaders must implement this interface. The loader is responsible
+    for reading data from a specific format and returning a Dataset object.
+
+    Example:
+        ```python
+        class MyLoader(BaseDatasetLoader):
+            def load(self, path: Path) -> Dataset:
+                # Implement loading logic
+                ...
+
+            def validate(self, data: Any) -> bool:
+                # Implement validation logic
+                ...
+        ```
+    """
+
+    @abstractmethod
+    def load(self, path: Path) -> Dataset:
+        """Load a dataset from the specified path.
+
+        Args:
+            path: Path to the dataset file.
+
+        Returns:
+            Loaded Dataset object.
+
+        Raises:
+            DatasetNotFoundError: If the file does not exist.
+            InvalidDatasetError: If the file format is invalid.
+            DatasetValidationError: If the data fails validation.
+        """
+        ...
+
+    @abstractmethod
+    def validate(self, data: Any) -> bool:
+        """Validate that the data conforms to the expected schema.
+
+        Args:
+            data: The data to validate.
+
+        Returns:
+            True if valid, False otherwise.
+
+        Raises:
+            DatasetValidationError: If validation fails with details.
+        """
+        ...
+
+    def _validate_path(self, path: Path) -> None:
+        """Validate that the path exists and is a file.
+
+        Args:
+            path: Path to validate.
+
+        Raises:
+            DatasetNotFoundError: If the path does not exist.
+        """
+        if not path.exists():
+            from openagent_eval.exceptions import DatasetNotFoundError
+
+            raise DatasetNotFoundError(dataset_path=str(path))
+
+        if not path.is_file():
+            from openagent_eval.exceptions import InvalidDatasetError
+
+            raise InvalidDatasetError(
+                message=f"Path is not a file: {path}",
+                dataset_path=str(path),
+            )

--- a/openagent_eval/datasets/csv_loader.py
+++ b/openagent_eval/datasets/csv_loader.py
@@ -1,0 +1,178 @@
+"""CSV dataset loader.
+
+This module implements the dataset loader for CSV format files.
+The CSV should have a header row with column names.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+from openagent_eval.datasets.base import BaseDatasetLoader, Dataset, DatasetItem
+from openagent_eval.datasets.models import DatasetItemModel
+from openagent_eval.exceptions import DatasetValidationError, InvalidDatasetError
+
+
+class CSVDatasetLoader(BaseDatasetLoader):
+    """Loader for CSV format datasets.
+
+    Expects a CSV file with a header row. Required column: `question`.
+    Optional columns: `ground_truth`, `context`, `metadata`.
+
+    Example CSV:
+    ```csv
+    question,ground_truth,context
+    "What is Python?","Python is a programming language.","Python is a high-level language."
+    "What is RAG?","Retrieval-Augmented Generation.","RAG combines retrieval and generation."
+    ```
+
+    Example:
+        ```python
+        from openagent_eval.datasets import CSVDatasetLoader
+        from pathlib import Path
+
+        loader = CSVDatasetLoader()
+        dataset = loader.load(Path("data/questions.csv"))
+        ```
+    """
+
+    REQUIRED_COLUMNS = {"question"}
+    OPTIONAL_COLUMNS = {"ground_truth", "context", "metadata"}
+
+    def load(self, path: Path) -> Dataset:
+        """Load a dataset from a CSV file.
+
+        Args:
+            path: Path to the CSV file.
+
+        Returns:
+            Loaded Dataset object.
+
+        Raises:
+            DatasetNotFoundError: If the file does not exist.
+            InvalidDatasetError: If the CSV is malformed.
+            DatasetValidationError: If the data fails validation.
+        """
+        self._validate_path(path)
+
+        try:
+            with open(path, encoding="utf-8", newline="") as f:
+                reader = csv.DictReader(f)
+                rows = list(reader)
+        except csv.Error as e:
+            raise InvalidDatasetError(
+                message=f"Invalid CSV format: {e}",
+                dataset_path=str(path),
+                format="csv",
+            ) from e
+
+        return self._parse_rows(rows, path)
+
+    def validate(self, data: Any) -> bool:
+        """Validate that the data conforms to the expected CSV schema.
+
+        Args:
+            data: The data to validate (should be a list of dicts).
+
+        Returns:
+            True if valid.
+
+        Raises:
+            DatasetValidationError: If validation fails.
+        """
+        if not isinstance(data, list):
+            raise DatasetValidationError(
+                message="Dataset must be a list of entries",
+                validation_errors=["Expected list, got " + type(data).__name__],
+            )
+
+        if not data:
+            raise DatasetValidationError(
+                message="Dataset is empty",
+                validation_errors=["No rows found in CSV"],
+            )
+
+        errors: list[str] = []
+        for i, item in enumerate(data):
+            if not isinstance(item, dict):
+                errors.append(f"Row {i + 1}: Expected dict, got {type(item).__name__}")
+                continue
+
+            if "question" not in item:
+                errors.append(f"Row {i + 1}: Missing required column 'question'")
+            elif not isinstance(item["question"], str) or not item["question"].strip():
+                errors.append(f"Row {i + 1}: 'question' must be a non-empty string")
+
+        if errors:
+            raise DatasetValidationError(
+                message=f"Dataset validation failed with {len(errors)} error(s)",
+                validation_errors=errors,
+            )
+
+        return True
+
+    def _parse_rows(self, rows: list[dict[str, str]], path: Path) -> Dataset:
+        """Parse CSV rows into a Dataset object.
+
+        Args:
+            rows: List of row dictionaries from the CSV reader.
+            path: Path to the source file (for error reporting).
+
+        Returns:
+            Dataset object.
+
+        Raises:
+            DatasetValidationError: If parsing or validation fails.
+        """
+        # Validate the raw data
+        self.validate(rows)
+
+        items: list[DatasetItem] = []
+        validation_errors: list[str] = []
+
+        for i, row in enumerate(rows):
+            try:
+                # Build item data from CSV columns
+                item_data: dict[str, Any] = {"question": row.get("question", "").strip()}
+
+                # Add optional fields if present
+                if "ground_truth" in row and row["ground_truth"]:
+                    item_data["ground_truth"] = row["ground_truth"].strip()
+                if "context" in row and row["context"]:
+                    item_data["context"] = row["context"].strip()
+                if "metadata" in row and row["metadata"]:
+                    # Try to parse metadata as JSON
+                    import json
+
+                    try:
+                        item_data["metadata"] = json.loads(row["metadata"])
+                    except (json.JSONDecodeError, TypeError):
+                        item_data["metadata"] = {"raw": row["metadata"]}
+
+                model = DatasetItemModel(**item_data)
+                items.append(
+                    DatasetItem(
+                        question=model.question,
+                        ground_truth=model.ground_truth,
+                        context=model.context,
+                        metadata=model.metadata,
+                        contexts=model.contexts,
+                    )
+                )
+            except Exception as e:
+                validation_errors.append(f"Row {i + 1}: {e}")
+
+        if validation_errors:
+            raise DatasetValidationError(
+                message=f"Failed to parse {len(validation_errors)} row(s)",
+                dataset_path=str(path),
+                validation_errors=validation_errors,
+            )
+
+        return Dataset(
+            items=items,
+            name=path.stem,
+            metadata={"source": str(path), "format": "csv"},
+        )

--- a/openagent_eval/datasets/hf_loader.py
+++ b/openagent_eval/datasets/hf_loader.py
@@ -1,0 +1,283 @@
+"""HuggingFace dataset loader.
+
+This module implements the dataset loader for HuggingFace datasets.
+Requires the `datasets` package to be installed.
+
+Note: This loader is optional and requires the `datasets` extra:
+    pip install openagent-eval[datasets]
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from openagent_eval.datasets.base import BaseDatasetLoader, Dataset, DatasetItem
+from openagent_eval.datasets.models import DatasetItemModel
+from openagent_eval.exceptions import DatasetValidationError, InvalidDatasetError
+
+
+class HFDatasetLoader(BaseDatasetLoader):
+    """Loader for HuggingFace datasets.
+
+    This loader can load datasets from:
+    - HuggingFace Hub (e.g., "squad", "natural_questions")
+    - Local dataset directories
+
+    Requires the `datasets` package:
+        pip install openagent-eval[datasets]
+
+    Example:
+        ```python
+        from openagent_eval.datasets import HFDatasetLoader
+
+        loader = HFDatasetLoader()
+        dataset = loader.load_from_hub("squad", split="train", limit=100)
+        ```
+
+    Note:
+        The `load()` method is not used for HuggingFace datasets.
+        Use `load_from_hub()` or `load_from_disk()` instead.
+    """
+
+    def load(self, path: Path) -> Dataset:
+        """Load a dataset from a local HuggingFace dataset directory.
+
+        Args:
+            path: Path to the local dataset directory.
+
+        Returns:
+            Loaded Dataset object.
+
+        Raises:
+            DatasetNotFoundError: If the directory does not exist.
+            InvalidDatasetError: If the dataset format is invalid.
+            DatasetValidationError: If the data fails validation.
+        """
+        # Validate path exists (can be directory for HF datasets)
+        if not path.exists():
+            from openagent_eval.exceptions import DatasetNotFoundError
+
+            raise DatasetNotFoundError(dataset_path=str(path))
+
+        try:
+            from datasets import load_from_disk
+        except ImportError as e:
+            raise InvalidDatasetError(
+                message=(
+                    "The 'datasets' package is required for HuggingFace dataset loading. "
+                    "Install it with: pip install openagent-eval[datasets]"
+                ),
+                dataset_path=str(path),
+                format="hf",
+            ) from e
+
+        try:
+            hf_dataset = load_from_disk(str(path))
+        except Exception as e:
+            raise InvalidDatasetError(
+                message=f"Failed to load HuggingFace dataset: {e}",
+                dataset_path=str(path),
+                format="hf",
+            ) from e
+
+        return self._parse_hf_dataset(hf_dataset, path)
+
+    def validate(self, data: Any) -> bool:
+        """Validate that the data conforms to the expected schema.
+
+        Args:
+            data: The data to validate (should be a list of dicts).
+
+        Returns:
+            True if valid.
+
+        Raises:
+            DatasetValidationError: If validation fails.
+        """
+        if not isinstance(data, list):
+            raise DatasetValidationError(
+                message="Dataset must be a list of entries",
+                validation_errors=["Expected list, got " + type(data).__name__],
+            )
+
+        errors: list[str] = []
+        for i, item in enumerate(data):
+            if not isinstance(item, dict):
+                errors.append(f"Item {i}: Expected dict, got {type(item).__name__}")
+                continue
+
+            if "question" not in item:
+                errors.append(f"Item {i}: Missing required field 'question'")
+            elif not isinstance(item["question"], str) or not item["question"].strip():
+                errors.append(f"Item {i}: 'question' must be a non-empty string")
+
+        if errors:
+            raise DatasetValidationError(
+                message=f"Dataset validation failed with {len(errors)} error(s)",
+                validation_errors=errors,
+            )
+
+        return True
+
+    def load_from_hub(
+        self,
+        dataset_name: str,
+        split: str = "train",
+        limit: int | None = None,
+        **kwargs: Any,
+    ) -> Dataset:
+        """Load a dataset from the HuggingFace Hub.
+
+        Args:
+            dataset_name: Name of the dataset on HuggingFace Hub.
+            split: Dataset split to load (default: "train").
+            limit: Maximum number of items to load.
+            **kwargs: Additional arguments to pass to `datasets.load_dataset`.
+
+        Returns:
+            Loaded Dataset object.
+
+        Raises:
+            InvalidDatasetError: If the dataset cannot be loaded.
+            DatasetValidationError: If the data fails validation.
+        """
+        try:
+            from datasets import load_dataset
+        except ImportError as e:
+            raise InvalidDatasetError(
+                message=(
+                    "The 'datasets' package is required for HuggingFace dataset loading. "
+                    "Install it with: pip install openagent-eval[datasets]"
+                ),
+                format="hf",
+            ) from e
+
+        try:
+            hf_dataset = load_dataset(dataset_name, split=split, **kwargs)
+        except Exception as e:
+            raise InvalidDatasetError(
+                message=f"Failed to load dataset '{dataset_name}': {e}",
+                format="hf",
+            ) from e
+
+        # Convert to list and apply limit
+        data = [dict(item) for item in hf_dataset]
+        if limit is not None:
+            data = data[:limit]
+
+        return self._parse_data(data, dataset_name)
+
+    def _parse_hf_dataset(self, hf_dataset: Any, path: Path) -> Dataset:
+        """Parse a HuggingFace dataset object into our Dataset model.
+
+        Args:
+            hf_dataset: The HuggingFace dataset object.
+            path: Path or name of the dataset.
+
+        Returns:
+            Dataset object.
+        """
+        data = [dict(item) for item in hf_dataset]
+        return self._parse_data(data, str(path))
+
+    def _parse_data(self, data: list[dict[str, Any]], source: str) -> Dataset:
+        """Parse a list of dictionaries into a Dataset object.
+
+        Args:
+            data: List of raw data dictionaries.
+            source: Source identifier (path or dataset name).
+
+        Returns:
+            Dataset object.
+
+        Raises:
+            DatasetValidationError: If parsing fails.
+        """
+        # Validate the raw data
+        self.validate(data)
+
+        items: list[DatasetItem] = []
+        validation_errors: list[str] = []
+
+        for i, raw_item in enumerate(data):
+            try:
+                # Map common HuggingFace field names to our schema
+                mapped = self._map_fields(raw_item)
+                model = DatasetItemModel(**mapped)
+                items.append(
+                    DatasetItem(
+                        question=model.question,
+                        ground_truth=model.ground_truth,
+                        context=model.context,
+                        metadata=model.metadata,
+                        contexts=model.contexts,
+                    )
+                )
+            except Exception as e:
+                validation_errors.append(f"Item {i}: {e}")
+
+        if validation_errors:
+            raise DatasetValidationError(
+                message=f"Failed to parse {len(validation_errors)} item(s)",
+                validation_errors=validation_errors,
+            )
+
+        return Dataset(
+            items=items,
+            name=source,
+            metadata={"source": source, "format": "hf"},
+        )
+
+    def _map_fields(self, raw_item: dict[str, Any]) -> dict[str, Any]:
+        """Map common HuggingFace field names to our schema.
+
+        This handles common variations in field naming across different
+        HuggingFace datasets.
+
+        Args:
+            raw_item: Raw item from HuggingFace dataset.
+
+        Returns:
+            Mapped item with standardized field names.
+        """
+        mapped: dict[str, Any] = {}
+
+        # Question field mappings
+        question_fields = ["question", "query", "input", "prompt"]
+        for field in question_fields:
+            if field in raw_item and raw_item[field]:
+                mapped["question"] = str(raw_item[field])
+                break
+
+        # Ground truth field mappings
+        ground_truth_fields = ["answer", "answers", "ground_truth", "target", "output", "response"]
+        for field in ground_truth_fields:
+            if field in raw_item and raw_item[field]:
+                value = raw_item[field]
+                # Handle list of answers (common in QA datasets)
+                if isinstance(value, list):
+                    if value:
+                        first = value[0]
+                        if isinstance(first, dict) and "text" in first:
+                            mapped["ground_truth"] = first["text"]
+                        elif isinstance(first, str):
+                            mapped["ground_truth"] = first
+                elif isinstance(value, str):
+                    mapped["ground_truth"] = value
+                break
+
+        # Context field mappings
+        context_fields = ["context", "passage", "document", "paragraph", "text"]
+        for field in context_fields:
+            if field in raw_item and raw_item[field]:
+                mapped["context"] = str(raw_item[field])
+                break
+
+        # Metadata - include all other fields
+        metadata_fields = set(mapped.keys()) | {"question", "ground_truth", "context"}
+        metadata = {k: v for k, v in raw_item.items() if k not in metadata_fields}
+        if metadata:
+            mapped["metadata"] = metadata
+
+        return mapped

--- a/openagent_eval/datasets/json_loader.py
+++ b/openagent_eval/datasets/json_loader.py
@@ -1,0 +1,156 @@
+"""JSON dataset loader.
+
+This module implements the dataset loader for JSON format files.
+The expected format is a JSON array of dataset entries.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from openagent_eval.datasets.base import BaseDatasetLoader, Dataset, DatasetItem
+from openagent_eval.datasets.models import DatasetItemModel, DatasetModel
+from openagent_eval.exceptions import DatasetValidationError, InvalidDatasetError
+
+
+class JSONDatasetLoader(BaseDatasetLoader):
+    """Loader for JSON format datasets.
+
+    Expects a JSON file containing an array of dataset entries:
+
+    ```json
+    [
+        {
+            "question": "What is Python?",
+            "ground_truth": "Python is a programming language.",
+            "context": "Python is a high-level programming language.",
+            "metadata": {"id": 1}
+        }
+    ]
+    ```
+
+    Example:
+        ```python
+        from openagent_eval.datasets import JSONDatasetLoader
+        from pathlib import Path
+
+        loader = JSONDatasetLoader()
+        dataset = loader.load(Path("data/questions.json"))
+        ```
+    """
+
+    def load(self, path: Path) -> Dataset:
+        """Load a dataset from a JSON file.
+
+        Args:
+            path: Path to the JSON file.
+
+        Returns:
+            Loaded Dataset object.
+
+        Raises:
+            DatasetNotFoundError: If the file does not exist.
+            InvalidDatasetError: If the JSON is malformed.
+            DatasetValidationError: If the data fails validation.
+        """
+        self._validate_path(path)
+
+        try:
+            raw_data = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            raise InvalidDatasetError(
+                message=f"Invalid JSON in file: {e}",
+                dataset_path=str(path),
+                format="json",
+                line_number=e.lineno,
+            ) from e
+
+        return self._parse_data(raw_data, path)
+
+    def validate(self, data: Any) -> bool:
+        """Validate that the data conforms to the expected JSON schema.
+
+        Args:
+            data: The data to validate (should be a list of dicts).
+
+        Returns:
+            True if valid.
+
+        Raises:
+            DatasetValidationError: If validation fails.
+        """
+        if not isinstance(data, list):
+            raise DatasetValidationError(
+                message="Dataset must be a JSON array",
+                validation_errors=["Expected array, got " + type(data).__name__],
+            )
+
+        errors: list[str] = []
+        for i, item in enumerate(data):
+            if not isinstance(item, dict):
+                errors.append(f"Item {i}: Expected dict, got {type(item).__name__}")
+                continue
+
+            if "question" not in item:
+                errors.append(f"Item {i}: Missing required field 'question'")
+            elif not isinstance(item["question"], str) or not item["question"].strip():
+                errors.append(f"Item {i}: 'question' must be a non-empty string")
+
+        if errors:
+            raise DatasetValidationError(
+                message=f"Dataset validation failed with {len(errors)} error(s)",
+                validation_errors=errors,
+            )
+
+        return True
+
+    def _parse_data(self, raw_data: Any, path: Path) -> Dataset:
+        """Parse raw JSON data into a Dataset object.
+
+        Args:
+            raw_data: The parsed JSON data.
+            path: Path to the source file (for error reporting).
+
+        Returns:
+            Dataset object.
+
+        Raises:
+            InvalidDatasetError: If the data structure is invalid.
+            DatasetValidationError: If validation fails.
+        """
+        # Validate the raw data
+        self.validate(raw_data)
+
+        # Parse each item through Pydantic validation
+        items: list[DatasetItem] = []
+        validation_errors: list[str] = []
+
+        for i, raw_item in enumerate(raw_data):
+            try:
+                model = DatasetItemModel(**raw_item)
+                items.append(
+                    DatasetItem(
+                        question=model.question,
+                        ground_truth=model.ground_truth,
+                        context=model.context,
+                        metadata=model.metadata,
+                        contexts=model.contexts,
+                    )
+                )
+            except Exception as e:
+                validation_errors.append(f"Item {i}: {e}")
+
+        if validation_errors:
+            raise DatasetValidationError(
+                message=f"Failed to parse {len(validation_errors)} item(s)",
+                dataset_path=str(path),
+                validation_errors=validation_errors,
+            )
+
+        return Dataset(
+            items=items,
+            name=path.stem,
+            metadata={"source": str(path), "format": "json"},
+        )

--- a/openagent_eval/datasets/jsonl_loader.py
+++ b/openagent_eval/datasets/jsonl_loader.py
@@ -1,0 +1,165 @@
+"""JSONL dataset loader.
+
+This module implements the dataset loader for JSONL (JSON Lines) format files.
+Each line in the file should be a valid JSON object representing one dataset entry.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from openagent_eval.datasets.base import BaseDatasetLoader, Dataset, DatasetItem
+from openagent_eval.datasets.models import DatasetItemModel
+from openagent_eval.exceptions import DatasetValidationError, InvalidDatasetError
+
+
+class JSONLDatasetLoader(BaseDatasetLoader):
+    """Loader for JSONL (JSON Lines) format datasets.
+
+    Expects a file where each line is a valid JSON object:
+
+    ```
+    {"question": "What is Python?", "ground_truth": "A programming language."}
+    {"question": "What is RAG?", "ground_truth": "Retrieval-Augmented Generation."}
+    ```
+
+    Example:
+        ```python
+        from openagent_eval.datasets import JSONLDatasetLoader
+        from pathlib import Path
+
+        loader = JSONLDatasetLoader()
+        dataset = loader.load(Path("data/questions.jsonl"))
+        ```
+    """
+
+    def load(self, path: Path) -> Dataset:
+        """Load a dataset from a JSONL file.
+
+        Args:
+            path: Path to the JSONL file.
+
+        Returns:
+            Loaded Dataset object.
+
+        Raises:
+            DatasetNotFoundError: If the file does not exist.
+            InvalidDatasetError: If a line contains invalid JSON.
+            DatasetValidationError: If the data fails validation.
+        """
+        self._validate_path(path)
+
+        lines = path.read_text(encoding="utf-8").splitlines()
+        return self._parse_lines(lines, path)
+
+    def validate(self, data: Any) -> bool:
+        """Validate that the data conforms to the expected JSONL schema.
+
+        Args:
+            data: The data to validate (should be a list of dicts).
+
+        Returns:
+            True if valid.
+
+        Raises:
+            DatasetValidationError: If validation fails.
+        """
+        if not isinstance(data, list):
+            raise DatasetValidationError(
+                message="Dataset must be a list of entries",
+                validation_errors=["Expected list, got " + type(data).__name__],
+            )
+
+        errors: list[str] = []
+        for i, item in enumerate(data):
+            if not isinstance(item, dict):
+                errors.append(f"Item {i}: Expected dict, got {type(item).__name__}")
+                continue
+
+            if "question" not in item:
+                errors.append(f"Item {i}: Missing required field 'question'")
+            elif not isinstance(item["question"], str) or not item["question"].strip():
+                errors.append(f"Item {i}: 'question' must be a non-empty string")
+
+        if errors:
+            raise DatasetValidationError(
+                message=f"Dataset validation failed with {len(errors)} error(s)",
+                validation_errors=errors,
+            )
+
+        return True
+
+    def _parse_lines(self, lines: list[str], path: Path) -> Dataset:
+        """Parse JSONL lines into a Dataset object.
+
+        Args:
+            lines: List of lines from the JSONL file.
+            path: Path to the source file (for error reporting).
+
+        Returns:
+            Dataset object.
+
+        Raises:
+            InvalidDatasetError: If a line contains invalid JSON.
+            DatasetValidationError: If validation fails.
+        """
+        import json
+
+        items: list[DatasetItem] = []
+        validation_errors: list[str] = []
+
+        for line_num, line in enumerate(lines, start=1):
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                raw_item = json.loads(line)
+            except json.JSONDecodeError as e:
+                raise InvalidDatasetError(
+                    message=f"Invalid JSON on line {line_num}: {e}",
+                    dataset_path=str(path),
+                    format="jsonl",
+                    line_number=line_num,
+                ) from e
+
+            if not isinstance(raw_item, dict):
+                validation_errors.append(
+                    f"Line {line_num}: Expected dict, got {type(raw_item).__name__}"
+                )
+                continue
+
+            try:
+                model = DatasetItemModel(**raw_item)
+                items.append(
+                    DatasetItem(
+                        question=model.question,
+                        ground_truth=model.ground_truth,
+                        context=model.context,
+                        metadata=model.metadata,
+                        contexts=model.contexts,
+                    )
+                )
+            except Exception as e:
+                validation_errors.append(f"Line {line_num}: {e}")
+
+        if validation_errors:
+            raise DatasetValidationError(
+                message=f"Failed to parse {len(validation_errors)} item(s)",
+                dataset_path=str(path),
+                validation_errors=validation_errors,
+            )
+
+        if not items:
+            raise DatasetValidationError(
+                message="Dataset is empty (no valid items found)",
+                dataset_path=str(path),
+                validation_errors=["No valid items in file"],
+            )
+
+        return Dataset(
+            items=items,
+            name=path.stem,
+            metadata={"source": str(path), "format": "jsonl"},
+        )

--- a/openagent_eval/datasets/models.py
+++ b/openagent_eval/datasets/models.py
@@ -1,0 +1,84 @@
+"""Pydantic models for dataset validation.
+
+This module defines the Pydantic models used for validating dataset entries
+and enforcing the expected schema.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class DatasetItemModel(BaseModel):
+    """Pydantic model for validating a single dataset entry.
+
+    This model enforces the schema for dataset items. The `question` field is
+    required, while `ground_truth`, `context`, and `metadata` are optional.
+
+    Attributes:
+        question: The question to evaluate (required).
+        ground_truth: The expected correct answer.
+        context: The context provided to the RAG system.
+        metadata: Additional metadata about this item.
+        contexts: List of retrieved contexts (populated after retrieval).
+    """
+
+    question: str = Field(..., min_length=1, description="The question to evaluate")
+    ground_truth: str | None = Field(None, description="The expected correct answer")
+    context: str | None = Field(None, description="The context provided to the RAG system")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
+    contexts: list[str] = Field(default_factory=list, description="Retrieved contexts")
+
+    @field_validator("question")
+    @classmethod
+    def validate_question(cls, v: str) -> str:
+        """Validate that the question is not empty or whitespace-only."""
+        if not v.strip():
+            raise ValueError("Question cannot be empty or whitespace-only")
+        return v.strip()
+
+    @field_validator("ground_truth")
+    @classmethod
+    def validate_ground_truth(cls, v: str | None) -> str | None:
+        """Validate ground truth if provided."""
+        if v is not None and not v.strip():
+            return None
+        return v
+
+    @field_validator("context")
+    @classmethod
+    def validate_context(cls, v: str | None) -> str | None:
+        """Validate context if provided."""
+        if v is not None and not v.strip():
+            return None
+        return v
+
+
+class DatasetModel(BaseModel):
+    """Pydantic model for validating an entire dataset.
+
+    This model validates a list of dataset entries, ensuring each entry
+    conforms to the expected schema.
+
+    Attributes:
+        items: List of validated dataset items.
+        name: Optional name for the dataset.
+        metadata: Dataset-level metadata.
+    """
+
+    items: list[DatasetItemModel] = Field(
+        default_factory=list,
+        description="List of dataset items",
+    )
+    name: str | None = Field(None, description="Dataset name")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Dataset metadata")
+
+    @field_validator("items")
+    @classmethod
+    def validate_items_not_empty(cls, v: list[DatasetItemModel]) -> list[DatasetItemModel]:
+        """Validate that the dataset is not empty."""
+        if not v:
+            raise ValueError("Dataset cannot be empty")
+        return v

--- a/tests/unit/test_datasets/test_base.py
+++ b/tests/unit/test_datasets/test_base.py
@@ -1,0 +1,168 @@
+"""Tests for base dataset models (DatasetItem, Dataset)."""
+
+from __future__ import annotations
+
+import pytest
+
+from openagent_eval.datasets.base import Dataset, DatasetItem
+
+
+class TestDatasetItem:
+    """Tests for DatasetItem dataclass."""
+
+    def test_create_minimal_item(self) -> None:
+        """Test creating a minimal item with only question."""
+        item = DatasetItem(question="What is Python?")
+        assert item.question == "What is Python?"
+        assert item.ground_truth is None
+        assert item.context is None
+        assert item.metadata == {}
+        assert item.contexts == []
+
+    def test_create_full_item(self) -> None:
+        """Test creating a full item with all fields."""
+        item = DatasetItem(
+            question="What is Python?",
+            ground_truth="Python is a programming language.",
+            context="Python is a high-level language.",
+            metadata={"id": 1, "source": "docs"},
+            contexts=["Context 1", "Context 2"],
+        )
+        assert item.question == "What is Python?"
+        assert item.ground_truth == "Python is a programming language."
+        assert item.context == "Python is a high-level language."
+        assert item.metadata == {"id": 1, "source": "docs"}
+        assert item.contexts == ["Context 1", "Context 2"]
+
+    def test_to_dict_minimal(self) -> None:
+        """Test to_dict with minimal item."""
+        item = DatasetItem(question="What is Python?")
+        d = item.to_dict()
+        assert d == {"question": "What is Python?"}
+
+    def test_to_dict_full(self) -> None:
+        """Test to_dict with full item."""
+        item = DatasetItem(
+            question="What is Python?",
+            ground_truth="A language.",
+            context="Some context.",
+            metadata={"id": 1},
+        )
+        d = item.to_dict()
+        assert d["question"] == "What is Python?"
+        assert d["ground_truth"] == "A language."
+        assert d["context"] == "Some context."
+        assert d["metadata"] == {"id": 1}
+
+    def test_to_dict_excludes_none(self) -> None:
+        """Test that to_dict excludes None values."""
+        item = DatasetItem(question="Q", ground_truth=None, context=None)
+        d = item.to_dict()
+        assert "ground_truth" not in d
+        assert "context" not in d
+
+
+class TestDataset:
+    """Tests for Dataset dataclass."""
+
+    def test_create_empty_dataset(self) -> None:
+        """Test creating an empty dataset."""
+        dataset = Dataset()
+        assert dataset.size == 0
+        assert len(dataset) == 0
+        assert dataset.items == []
+        assert dataset.name is None
+        assert dataset.metadata == {}
+
+    def test_create_dataset_with_items(self) -> None:
+        """Test creating a dataset with items."""
+        items = [
+            DatasetItem(question="Q1"),
+            DatasetItem(question="Q2"),
+        ]
+        dataset = Dataset(items=items, name="test")
+        assert dataset.size == 2
+        assert len(dataset) == 2
+        assert dataset.name == "test"
+
+    def test_size_property(self) -> None:
+        """Test size property."""
+        dataset = Dataset(items=[DatasetItem(question="Q1")])
+        assert dataset.size == 1
+
+    def test_has_ground_truth_true(self) -> None:
+        """Test has_ground_truth when all items have ground truth."""
+        items = [
+            DatasetItem(question="Q1", ground_truth="A1"),
+            DatasetItem(question="Q2", ground_truth="A2"),
+        ]
+        dataset = Dataset(items=items)
+        assert dataset.has_ground_truth is True
+
+    def test_has_ground_truth_false(self) -> None:
+        """Test has_ground_truth when some items lack ground truth."""
+        items = [
+            DatasetItem(question="Q1", ground_truth="A1"),
+            DatasetItem(question="Q2"),
+        ]
+        dataset = Dataset(items=items)
+        assert dataset.has_ground_truth is False
+
+    def test_questions_property(self) -> None:
+        """Test questions property."""
+        items = [
+            DatasetItem(question="Q1"),
+            DatasetItem(question="Q2"),
+            DatasetItem(question="Q3"),
+        ]
+        dataset = Dataset(items=items)
+        assert dataset.questions == ["Q1", "Q2", "Q3"]
+
+    def test_iter(self) -> None:
+        """Test iteration over dataset."""
+        items = [DatasetItem(question="Q1"), DatasetItem(question="Q2")]
+        dataset = Dataset(items=items)
+        collected = [item.question for item in dataset]
+        assert collected == ["Q1", "Q2"]
+
+    def test_getitem(self) -> None:
+        """Test indexing into dataset."""
+        items = [DatasetItem(question="Q1"), DatasetItem(question="Q2")]
+        dataset = Dataset(items=items)
+        assert dataset[0].question == "Q1"
+        assert dataset[1].question == "Q2"
+
+    def test_filter(self) -> None:
+        """Test filtering dataset items."""
+        items = [
+            DatasetItem(question="Q1", ground_truth="A1"),
+            DatasetItem(question="Q2"),
+            DatasetItem(question="Q3", ground_truth="A3"),
+        ]
+        dataset = Dataset(items=items)
+        filtered = dataset.filter(lambda item: item.ground_truth is not None)
+        assert filtered.size == 2
+        assert filtered[0].question == "Q1"
+        assert filtered[1].question == "Q3"
+
+    def test_filter_preserves_metadata(self) -> None:
+        """Test that filter preserves dataset metadata."""
+        items = [DatasetItem(question="Q1")]
+        dataset = Dataset(items=items, name="test", metadata={"key": "value"})
+        filtered = dataset.filter(lambda item: True)
+        assert filtered.name == "test"
+        assert filtered.metadata == {"key": "value"}
+
+    def test_to_dicts(self) -> None:
+        """Test converting dataset to list of dicts."""
+        items = [
+            DatasetItem(question="Q1", ground_truth="A1"),
+            DatasetItem(question="Q2"),
+        ]
+        dataset = Dataset(items=items)
+        dicts = dataset.to_dicts()
+        assert len(dicts) == 2
+        assert dicts[0]["question"] == "Q1"
+        assert dicts[0]["ground_truth"] == "A1"
+        assert dicts[1]["question"] == "Q2"
+        assert "ground_truth" not in dicts[1]

--- a/tests/unit/test_datasets/test_csv_loader.py
+++ b/tests/unit/test_datasets/test_csv_loader.py
@@ -1,0 +1,139 @@
+"""Tests for CSV dataset loader."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from openagent_eval.datasets.csv_loader import CSVDatasetLoader
+from openagent_eval.exceptions import (
+    DatasetNotFoundError,
+    DatasetValidationError,
+)
+
+
+class TestCSVDatasetLoader:
+    """Tests for CSVDatasetLoader."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        self.loader = CSVDatasetLoader()
+
+    def _write_csv(self, path: Path, rows: list[dict[str, str]]) -> None:
+        """Helper to write CSV file."""
+        if not rows:
+            path.write_text("", encoding="utf-8")
+            return
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+            writer.writeheader()
+            writer.writerows(rows)
+
+    def test_load_valid_csv(self, tmp_path: Path) -> None:
+        """Test loading a valid CSV dataset."""
+        rows = [
+            {"question": "What is Python?", "ground_truth": "A language.", "context": "Some context."},
+            {"question": "What is RAG?", "ground_truth": "Retrieval-Augmented Generation.", "context": "RAG info."},
+        ]
+        csv_path = tmp_path / "test.csv"
+        self._write_csv(csv_path, rows)
+
+        dataset = self.loader.load(csv_path)
+
+        assert dataset.size == 2
+        assert dataset.name == "test"
+        assert dataset[0].question == "What is Python?"
+        assert dataset[0].ground_truth == "A language."
+        assert dataset[0].context == "Some context."
+        assert dataset[1].question == "What is RAG?"
+
+    def test_load_minimal_csv(self, tmp_path: Path) -> None:
+        """Test loading CSV with only question column."""
+        rows = [{"question": "Q1"}, {"question": "Q2"}]
+        csv_path = tmp_path / "minimal.csv"
+        self._write_csv(csv_path, rows)
+
+        dataset = self.loader.load(csv_path)
+
+        assert dataset.size == 2
+        assert dataset[0].question == "Q1"
+        assert dataset[0].ground_truth is None
+
+    def test_load_file_not_found(self, tmp_path: Path) -> None:
+        """Test loading a non-existent file."""
+        csv_path = tmp_path / "nonexistent.csv"
+
+        with pytest.raises(DatasetNotFoundError):
+            self.loader.load(csv_path)
+
+    def test_load_missing_question_column(self, tmp_path: Path) -> None:
+        """Test loading CSV without question column."""
+        rows = [{"ground_truth": "A1"}, {"ground_truth": "A2"}]
+        csv_path = tmp_path / "no_question.csv"
+        self._write_csv(csv_path, rows)
+
+        with pytest.raises(DatasetValidationError):
+            self.loader.load(csv_path)
+
+    def test_load_empty_csv(self, tmp_path: Path) -> None:
+        """Test loading an empty CSV file."""
+        csv_path = tmp_path / "empty.csv"
+        csv_path.write_text("", encoding="utf-8")
+
+        with pytest.raises(DatasetValidationError):
+            self.loader.load(csv_path)
+
+    def test_load_with_metadata_json(self, tmp_path: Path) -> None:
+        """Test loading CSV with JSON metadata."""
+        rows = [
+            {"question": "Q1", "metadata": '{"id": 1, "source": "docs"}'},
+        ]
+        csv_path = tmp_path / "metadata.csv"
+        self._write_csv(csv_path, rows)
+
+        dataset = self.loader.load(csv_path)
+
+        assert dataset.size == 1
+        assert dataset[0].metadata == {"id": 1, "source": "docs"}
+
+    def test_load_with_invalid_metadata(self, tmp_path: Path) -> None:
+        """Test loading CSV with invalid JSON metadata."""
+        rows = [
+            {"question": "Q1", "metadata": "not json"},
+        ]
+        csv_path = tmp_path / "bad_meta.csv"
+        self._write_csv(csv_path, rows)
+
+        dataset = self.loader.load(csv_path)
+
+        # Invalid metadata should be stored as raw string
+        assert dataset.size == 1
+        assert dataset[0].metadata == {"raw": "not json"}
+
+    def test_validate_valid_data(self) -> None:
+        """Test validate with valid data."""
+        data = [{"question": "Q1"}, {"question": "Q2"}]
+        assert self.loader.validate(data) is True
+
+    def test_validate_not_list(self) -> None:
+        """Test validate with non-list data."""
+        with pytest.raises(DatasetValidationError):
+            self.loader.validate("not a list")
+
+    def test_validate_empty_list(self) -> None:
+        """Test validate with empty list."""
+        with pytest.raises(DatasetValidationError):
+            self.loader.validate([])
+
+    def test_dataset_metadata(self, tmp_path: Path) -> None:
+        """Test that dataset metadata is set correctly."""
+        rows = [{"question": "Q1"}]
+        csv_path = tmp_path / "meta.csv"
+        self._write_csv(csv_path, rows)
+
+        dataset = self.loader.load(csv_path)
+
+        assert dataset.metadata["format"] == "csv"
+        assert dataset.metadata["source"] == str(csv_path)

--- a/tests/unit/test_datasets/test_hf_loader.py
+++ b/tests/unit/test_datasets/test_hf_loader.py
@@ -1,0 +1,156 @@
+"""Tests for HuggingFace dataset loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openagent_eval.datasets.hf_loader import HFDatasetLoader
+from openagent_eval.exceptions import DatasetValidationError, InvalidDatasetError
+
+
+class TestHFDatasetLoader:
+    """Tests for HFDatasetLoader."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        self.loader = HFDatasetLoader()
+
+    def test_validate_valid_data(self) -> None:
+        """Test validate with valid data."""
+        data = [{"question": "Q1"}, {"question": "Q2"}]
+        assert self.loader.validate(data) is True
+
+    def test_validate_not_list(self) -> None:
+        """Test validate with non-list data."""
+        with pytest.raises(DatasetValidationError):
+            self.loader.validate("not a list")
+
+    def test_validate_missing_question(self) -> None:
+        """Test validate with missing question."""
+        data = [{"ground_truth": "A1"}]
+        with pytest.raises(DatasetValidationError):
+            self.loader.validate(data)
+
+    def test_validate_empty_question(self) -> None:
+        """Test validate with empty question."""
+        data = [{"question": ""}]
+        with pytest.raises(DatasetValidationError):
+            self.loader.validate(data)
+
+    def test_map_fields_standard(self) -> None:
+        """Test field mapping with standard fields."""
+        raw = {
+            "question": "What is Python?",
+            "answer": "A programming language.",
+            "context": "Some context.",
+        }
+        mapped = self.loader._map_fields(raw)
+        assert mapped["question"] == "What is Python?"
+        assert mapped["ground_truth"] == "A programming language."
+        assert mapped["context"] == "Some context."
+
+    def test_map_fields_alternative_names(self) -> None:
+        """Test field mapping with alternative field names."""
+        raw = {
+            "query": "What is RAG?",
+            "target": "Retrieval-Augmented Generation.",
+            "passage": "RAG info.",
+        }
+        mapped = self.loader._map_fields(raw)
+        assert mapped["question"] == "What is RAG?"
+        assert mapped["ground_truth"] == "Retrieval-Augmented Generation."
+        assert mapped["context"] == "RAG info."
+
+    def test_map_fields_list_answer(self) -> None:
+        """Test field mapping with list of answers."""
+        raw = {
+            "question": "Q1",
+            "answers": [{"text": "Answer 1"}, {"text": "Answer 2"}],
+        }
+        mapped = self.loader._map_fields(raw)
+        assert mapped["ground_truth"] == "Answer 1"
+
+    def test_map_fields_string_list_answer(self) -> None:
+        """Test field mapping with list of string answers."""
+        raw = {
+            "question": "Q1",
+            "answers": ["Answer 1", "Answer 2"],
+        }
+        mapped = self.loader._map_fields(raw)
+        assert mapped["ground_truth"] == "Answer 1"
+
+    def test_map_fields_metadata(self) -> None:
+        """Test that extra fields become metadata."""
+        raw = {
+            "question": "Q1",
+            "id": 1,
+            "source": "docs",
+        }
+        mapped = self.loader._map_fields(raw)
+        assert mapped["question"] == "Q1"
+        assert mapped["metadata"]["id"] == 1
+        assert mapped["metadata"]["source"] == "docs"
+
+    def test_load_from_hub_with_mock(self) -> None:
+        """Test load_from_hub with mocked datasets library."""
+        mock_dataset = [
+            {"question": "Q1", "answer": "A1"},
+            {"question": "Q2", "answer": "A2"},
+        ]
+
+        mock_datasets = MagicMock()
+        mock_datasets.load_dataset.return_value = mock_dataset
+
+        with patch.dict("sys.modules", {"datasets": mock_datasets}):
+            dataset = self.loader.load_from_hub("test_dataset", split="train")
+
+            assert dataset.size == 2
+            assert dataset[0].question == "Q1"
+            assert dataset[0].ground_truth == "A1"
+            mock_datasets.load_dataset.assert_called_once_with("test_dataset", split="train")
+
+    def test_load_from_hub_with_limit(self) -> None:
+        """Test load_from_hub with limit parameter."""
+        mock_dataset = [
+            {"question": "Q1", "answer": "A1"},
+            {"question": "Q2", "answer": "A2"},
+            {"question": "Q3", "answer": "A3"},
+        ]
+
+        mock_datasets = MagicMock()
+        mock_datasets.load_dataset.return_value = mock_dataset
+
+        with patch.dict("sys.modules", {"datasets": mock_datasets}):
+            dataset = self.loader.load_from_hub("test_dataset", limit=2)
+
+            assert dataset.size == 2
+
+    def test_load_from_hub_import_error(self) -> None:
+        """Test load_from_hub when datasets is not installed."""
+        with patch.dict("sys.modules", {"datasets": None}):
+            with pytest.raises(InvalidDatasetError) as exc_info:
+                self.loader.load_from_hub("test_dataset")
+            assert "datasets" in str(exc_info.value).lower()
+
+    def test_load_local_with_mock(self, tmp_path: Path) -> None:
+        """Test load from local directory with mocked datasets library."""
+        mock_dataset = [
+            {"question": "Q1", "answer": "A1"},
+        ]
+
+        mock_datasets = MagicMock()
+        mock_datasets.load_from_disk.return_value = mock_dataset
+
+        # Create the directory so _validate_path passes
+        local_dir = tmp_path / "local_dataset"
+        local_dir.mkdir()
+
+        with patch.dict("sys.modules", {"datasets": mock_datasets}):
+            dataset = self.loader.load(local_dir)
+
+            assert dataset.size == 1
+            mock_datasets.load_from_disk.assert_called_once_with(str(local_dir))

--- a/tests/unit/test_datasets/test_json_loader.py
+++ b/tests/unit/test_datasets/test_json_loader.py
@@ -1,0 +1,134 @@
+"""Tests for JSON dataset loader."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openagent_eval.datasets.json_loader import JSONDatasetLoader
+from openagent_eval.exceptions import (
+    DatasetNotFoundError,
+    DatasetValidationError,
+    InvalidDatasetError,
+)
+
+
+class TestJSONDatasetLoader:
+    """Tests for JSONDatasetLoader."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        self.loader = JSONDatasetLoader()
+
+    def test_load_valid_json(self, tmp_path: Path) -> None:
+        """Test loading a valid JSON dataset."""
+        data = [
+            {
+                "question": "What is Python?",
+                "ground_truth": "Python is a programming language.",
+                "context": "Python is a high-level language.",
+                "metadata": {"id": 1},
+            },
+            {
+                "question": "What is RAG?",
+                "ground_truth": "Retrieval-Augmented Generation.",
+                "context": "RAG combines retrieval and generation.",
+            },
+        ]
+        json_path = tmp_path / "test.json"
+        json_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+        dataset = self.loader.load(json_path)
+
+        assert dataset.size == 2
+        assert dataset.name == "test"
+        assert dataset[0].question == "What is Python?"
+        assert dataset[0].ground_truth == "Python is a programming language."
+        assert dataset[0].context == "Python is a high-level language."
+        assert dataset[0].metadata == {"id": 1}
+        assert dataset[1].question == "What is RAG?"
+
+    def test_load_minimal_json(self, tmp_path: Path) -> None:
+        """Test loading JSON with minimal fields."""
+        data = [{"question": "Q1"}, {"question": "Q2"}]
+        json_path = tmp_path / "minimal.json"
+        json_path.write_text(json.dumps(data), encoding="utf-8")
+
+        dataset = self.loader.load(json_path)
+
+        assert dataset.size == 2
+        assert dataset[0].question == "Q1"
+        assert dataset[0].ground_truth is None
+
+    def test_load_file_not_found(self, tmp_path: Path) -> None:
+        """Test loading a non-existent file."""
+        json_path = tmp_path / "nonexistent.json"
+
+        with pytest.raises(DatasetNotFoundError):
+            self.loader.load(json_path)
+
+    def test_load_invalid_json(self, tmp_path: Path) -> None:
+        """Test loading invalid JSON."""
+        json_path = tmp_path / "invalid.json"
+        json_path.write_text("not valid json {{{", encoding="utf-8")
+
+        with pytest.raises(InvalidDatasetError) as exc_info:
+            self.loader.load(json_path)
+        assert "Invalid JSON" in str(exc_info.value)
+
+    def test_load_non_array_json(self, tmp_path: Path) -> None:
+        """Test loading JSON that is not an array."""
+        json_path = tmp_path / "object.json"
+        json_path.write_text(json.dumps({"question": "Q1"}), encoding="utf-8")
+
+        with pytest.raises(DatasetValidationError):
+            self.loader.load(json_path)
+
+    def test_load_missing_question_field(self, tmp_path: Path) -> None:
+        """Test loading JSON with missing question field."""
+        data = [{"ground_truth": "A1"}, {"question": "Q2"}]
+        json_path = tmp_path / "missing_q.json"
+        json_path.write_text(json.dumps(data), encoding="utf-8")
+
+        with pytest.raises(DatasetValidationError) as exc_info:
+            self.loader.load(json_path)
+        assert "question" in str(exc_info.value).lower()
+
+    def test_load_empty_question(self, tmp_path: Path) -> None:
+        """Test loading JSON with empty question."""
+        data = [{"question": ""}, {"question": "Q2"}]
+        json_path = tmp_path / "empty_q.json"
+        json_path.write_text(json.dumps(data), encoding="utf-8")
+
+        with pytest.raises(DatasetValidationError):
+            self.loader.load(json_path)
+
+    def test_validate_valid_data(self) -> None:
+        """Test validate with valid data."""
+        data = [{"question": "Q1"}, {"question": "Q2"}]
+        assert self.loader.validate(data) is True
+
+    def test_validate_not_list(self) -> None:
+        """Test validate with non-list data."""
+        with pytest.raises(DatasetValidationError):
+            self.loader.validate({"question": "Q1"})
+
+    def test_validate_empty_list(self) -> None:
+        """Test validate with empty list."""
+        # Empty list should pass basic validation (items can be empty)
+        # But Pydantic model will reject it
+        data: list[dict] = []
+        assert self.loader.validate(data) is True
+
+    def test_dataset_metadata(self, tmp_path: Path) -> None:
+        """Test that dataset metadata is set correctly."""
+        data = [{"question": "Q1"}]
+        json_path = tmp_path / "meta.json"
+        json_path.write_text(json.dumps(data), encoding="utf-8")
+
+        dataset = self.loader.load(json_path)
+
+        assert dataset.metadata["format"] == "json"
+        assert dataset.metadata["source"] == str(json_path)

--- a/tests/unit/test_datasets/test_jsonl_loader.py
+++ b/tests/unit/test_datasets/test_jsonl_loader.py
@@ -1,0 +1,135 @@
+"""Tests for JSONL dataset loader."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openagent_eval.datasets.jsonl_loader import JSONLDatasetLoader
+from openagent_eval.exceptions import (
+    DatasetNotFoundError,
+    DatasetValidationError,
+    InvalidDatasetError,
+)
+
+
+class TestJSONLDatasetLoader:
+    """Tests for JSONLDatasetLoader."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        self.loader = JSONLDatasetLoader()
+
+    def test_load_valid_jsonl(self, tmp_path: Path) -> None:
+        """Test loading a valid JSONL dataset."""
+        lines = [
+            json.dumps({"question": "What is Python?", "ground_truth": "A language."}),
+            json.dumps({"question": "What is RAG?", "ground_truth": "Retrieval-Augmented Generation."}),
+        ]
+        jsonl_path = tmp_path / "test.jsonl"
+        jsonl_path.write_text("\n".join(lines), encoding="utf-8")
+
+        dataset = self.loader.load(jsonl_path)
+
+        assert dataset.size == 2
+        assert dataset.name == "test"
+        assert dataset[0].question == "What is Python?"
+        assert dataset[0].ground_truth == "A language."
+        assert dataset[1].question == "What is RAG?"
+
+    def test_load_with_blank_lines(self, tmp_path: Path) -> None:
+        """Test loading JSONL with blank lines."""
+        lines = [
+            json.dumps({"question": "Q1"}),
+            "",
+            "  ",
+            json.dumps({"question": "Q2"}),
+        ]
+        jsonl_path = tmp_path / "blanks.jsonl"
+        jsonl_path.write_text("\n".join(lines), encoding="utf-8")
+
+        dataset = self.loader.load(jsonl_path)
+
+        assert dataset.size == 2
+
+    def test_load_file_not_found(self, tmp_path: Path) -> None:
+        """Test loading a non-existent file."""
+        jsonl_path = tmp_path / "nonexistent.jsonl"
+
+        with pytest.raises(DatasetNotFoundError):
+            self.loader.load(jsonl_path)
+
+    def test_load_invalid_json_line(self, tmp_path: Path) -> None:
+        """Test loading JSONL with invalid JSON on a line."""
+        lines = [
+            json.dumps({"question": "Q1"}),
+            "not valid json {{{",
+        ]
+        jsonl_path = tmp_path / "invalid.jsonl"
+        jsonl_path.write_text("\n".join(lines), encoding="utf-8")
+
+        with pytest.raises(InvalidDatasetError) as exc_info:
+            self.loader.load(jsonl_path)
+        assert "Invalid JSON" in str(exc_info.value)
+
+    def test_load_missing_question(self, tmp_path: Path) -> None:
+        """Test loading JSONL with missing question field."""
+        lines = [
+            json.dumps({"ground_truth": "A1"}),
+            json.dumps({"question": "Q2"}),
+        ]
+        jsonl_path = tmp_path / "missing_q.jsonl"
+        jsonl_path.write_text("\n".join(lines), encoding="utf-8")
+
+        with pytest.raises(DatasetValidationError):
+            self.loader.load(jsonl_path)
+
+    def test_load_empty_file(self, tmp_path: Path) -> None:
+        """Test loading an empty JSONL file."""
+        jsonl_path = tmp_path / "empty.jsonl"
+        jsonl_path.write_text("", encoding="utf-8")
+
+        with pytest.raises(DatasetValidationError):
+            self.loader.load(jsonl_path)
+
+    def test_load_full_item(self, tmp_path: Path) -> None:
+        """Test loading JSONL with all fields."""
+        data = {
+            "question": "What is Python?",
+            "ground_truth": "A language.",
+            "context": "Some context.",
+            "metadata": {"id": 1},
+        }
+        jsonl_path = tmp_path / "full.jsonl"
+        jsonl_path.write_text(json.dumps(data), encoding="utf-8")
+
+        dataset = self.loader.load(jsonl_path)
+
+        assert dataset.size == 1
+        assert dataset[0].question == "What is Python?"
+        assert dataset[0].ground_truth == "A language."
+        assert dataset[0].context == "Some context."
+        assert dataset[0].metadata == {"id": 1}
+
+    def test_validate_valid_data(self) -> None:
+        """Test validate with valid data."""
+        data = [{"question": "Q1"}, {"question": "Q2"}]
+        assert self.loader.validate(data) is True
+
+    def test_validate_not_list(self) -> None:
+        """Test validate with non-list data."""
+        with pytest.raises(DatasetValidationError):
+            self.loader.validate("not a list")
+
+    def test_dataset_metadata(self, tmp_path: Path) -> None:
+        """Test that dataset metadata is set correctly."""
+        lines = [json.dumps({"question": "Q1"})]
+        jsonl_path = tmp_path / "meta.jsonl"
+        jsonl_path.write_text("\n".join(lines), encoding="utf-8")
+
+        dataset = self.loader.load(jsonl_path)
+
+        assert dataset.metadata["format"] == "jsonl"
+        assert dataset.metadata["source"] == str(jsonl_path)

--- a/tests/unit/test_datasets/test_models.py
+++ b/tests/unit/test_datasets/test_models.py
@@ -1,0 +1,91 @@
+"""Tests for dataset Pydantic validation models."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from openagent_eval.datasets.models import DatasetItemModel, DatasetModel
+
+
+class TestDatasetItemModel:
+    """Tests for DatasetItemModel Pydantic model."""
+
+    def test_valid_minimal_item(self) -> None:
+        """Test creating a valid minimal item."""
+        model = DatasetItemModel(question="What is Python?")
+        assert model.question == "What is Python?"
+        assert model.ground_truth is None
+        assert model.context is None
+        assert model.metadata == {}
+        assert model.contexts == []
+
+    def test_valid_full_item(self) -> None:
+        """Test creating a valid full item."""
+        model = DatasetItemModel(
+            question="What is Python?",
+            ground_truth="Python is a programming language.",
+            context="Python is a high-level language.",
+            metadata={"id": 1},
+            contexts=["Context 1"],
+        )
+        assert model.question == "What is Python?"
+        assert model.ground_truth == "Python is a programming language."
+        assert model.context == "Python is a high-level language."
+        assert model.metadata == {"id": 1}
+        assert model.contexts == ["Context 1"]
+
+    def test_question_strips_whitespace(self) -> None:
+        """Test that question whitespace is stripped."""
+        model = DatasetItemModel(question="  What is Python?  ")
+        assert model.question == "What is Python?"
+
+    def test_empty_question_raises_error(self) -> None:
+        """Test that empty question raises validation error."""
+        with pytest.raises(ValidationError) as exc_info:
+            DatasetItemModel(question="")
+        assert "question" in str(exc_info.value).lower()
+
+    def test_whitespace_question_raises_error(self) -> None:
+        """Test that whitespace-only question raises validation error."""
+        with pytest.raises(ValidationError):
+            DatasetItemModel(question="   ")
+
+    def test_ground_truth_empty_becomes_none(self) -> None:
+        """Test that empty ground_truth becomes None."""
+        model = DatasetItemModel(question="Q", ground_truth="  ")
+        assert model.ground_truth is None
+
+    def test_context_empty_becomes_none(self) -> None:
+        """Test that empty context becomes None."""
+        model = DatasetItemModel(question="Q", context="  ")
+        assert model.context is None
+
+
+class TestDatasetModel:
+    """Tests for DatasetModel Pydantic model."""
+
+    def test_valid_dataset(self) -> None:
+        """Test creating a valid dataset."""
+        model = DatasetModel(
+            items=[
+                DatasetItemModel(question="Q1"),
+                DatasetItemModel(question="Q2"),
+            ],
+            name="test",
+        )
+        assert len(model.items) == 2
+        assert model.name == "test"
+
+    def test_empty_dataset_raises_error(self) -> None:
+        """Test that empty dataset raises validation error."""
+        with pytest.raises(ValidationError):
+            DatasetModel(items=[])
+
+    def test_dataset_with_metadata(self) -> None:
+        """Test dataset with metadata."""
+        model = DatasetModel(
+            items=[DatasetItemModel(question="Q1")],
+            metadata={"source": "test"},
+        )
+        assert model.metadata == {"source": "test"}


### PR DESCRIPTION
## Summary

Implement the complete Data Layer for OpenAgent Eval (Phase 2), providing dataset loading and validation capabilities for JSON, JSONL, CSV, and HuggingFace formats.

## Motivation

Phase 2 is the next step after the Phase 1 Foundation. The data layer is essential for the evaluation pipeline to load and validate datasets before evaluation.

## Files Modified

### New Files
- openagent_eval/datasets/base.py - BaseDatasetLoader abstract interface, Dataset and DatasetItem dataclasses
- openagent_eval/datasets/models.py - Pydantic validation models (DatasetItemModel, DatasetModel)
- openagent_eval/datasets/json_loader.py - JSON format dataset loader
- openagent_eval/datasets/jsonl_loader.py - JSONL (JSON Lines) format dataset loader
- openagent_eval/datasets/csv_loader.py - CSV format dataset loader
- openagent_eval/datasets/hf_loader.py - HuggingFace dataset loader (optional dependency)
- 	ests/unit/test_datasets/test_base.py - Tests for base models (16 tests)
- 	ests/unit/test_datasets/test_models.py - Tests for Pydantic models (10 tests)
- 	ests/unit/test_datasets/test_json_loader.py - Tests for JSON loader (11 tests)
- 	ests/unit/test_datasets/test_jsonl_loader.py - Tests for JSONL loader (10 tests)
- 	ests/unit/test_datasets/test_csv_loader.py - Tests for CSV loader (11 tests)
- 	ests/unit/test_datasets/test_hf_loader.py - Tests for HuggingFace loader (13 tests)

### Modified Files
- openagent_eval/datasets/__init__.py - Updated with public API exports

## Architectural Decisions

- **BaseDatasetLoader** is an abstract base class that all loaders implement
- **Dataset** and **DatasetItem** are dataclasses (not Pydantic) for lightweight usage
- **DatasetItemModel** and **DatasetModel** are Pydantic models for validation
- HuggingFace loader is optional (requires datasets package)
- All loaders use the existing exception hierarchy (DatasetNotFoundError, InvalidDatasetError, DatasetValidationError)
- Field mapping in HF loader handles common HuggingFace dataset field name variations

## Breaking Changes

None - this is purely additive.

## Testing

- 71 new unit tests added (all passing)
- 121 total tests passing (50 from Phase 1 + 71 new)
- All external dependencies mocked (no real API calls)
- Tests cover success paths, error paths, and edge cases

## Remaining TODOs

- Phase 3: Metrics System
- Phase 4: Reports
- Phase 5: Providers
- Phase 6: Plugin System

## Assumptions & Limitations

- HuggingFace loader requires optional datasets package (pip install openagent-eval[datasets])
- CSV loader expects UTF-8 encoding
- JSONL loader skips blank lines gracefully