### PR TITLE
feat: add PDF dataset loader (PDFDatasetLoader)

### DIFF
--- a/.ai/03_CONTEXT.md
+++ b/.ai/03_CONTEXT.md
@@ -232,3 +232,4 @@ chore/{description}        # Maintenance tasks
 | 2026-07-08 | Phase 6 completed - Plugin System implemented |
 | 2026-07-08 | 27 new plugin tests added (517+ total) |
 | 2026-07-08 | Created plugin development guide |
+| 2026-07-10 | Added PDF dataset loader (PDFDatasetLoader) with pypdf optional dependency |

--- a/.ai/05_TASKS.md
+++ b/.ai/05_TASKS.md
@@ -111,6 +111,7 @@
 - [x] Implement JSONL dataset loader
 - [x] Implement CSV dataset loader
 - [x] Implement HuggingFace dataset loader
+- [x] Implement PDF dataset loader (pypdf, optional `pdf` extra)
 - [x] Create dataset validation (Pydantic models)
 - [x] Implement dataset schema enforcement
 - [x] Write unit tests for all loaders
@@ -215,3 +216,4 @@ Phase 8 (Documentation) ← can run in parallel with Phase 7
 | 2026-07-08 | PR #7 created for Phase 5 |
 | 2026-07-08 | Phase 6 completed - Plugin System implemented (27 new tests) |
 | 2026-07-08 | Created plugin development guide |
+| 2026-07-10 | Added PDF dataset loader (PDFDatasetLoader) with pypdf optional dependency |

--- a/openagent_eval/cli/utils/helpers.py
+++ b/openagent_eval/cli/utils/helpers.py
@@ -86,12 +86,16 @@ def apply_output_override(config: object, output: str | None) -> None:
 
 
 def load_dataset_for_run(config: object) -> list:
-    """Load dataset items from config."""
-    from openagent_eval.datasets import JSONDatasetLoader
+    """Load dataset items from config.
+
+    Auto-detects the dataset format from the file extension (or the explicit
+    ``format`` field in the configuration) and returns a list of item
+    dictionaries suitable for the evaluation engine.
+    """
+    from openagent_eval.datasets.factory import load_dataset
 
     try:
-        loader = JSONDatasetLoader()
-        return loader.load(Path(config.dataset.path))
+        return load_dataset(config.dataset)
     except Exception as e:
         raise ConfigurationError(
             message=f"Failed to load dataset: {e}",

--- a/openagent_eval/datasets/__init__.py
+++ b/openagent_eval/datasets/__init__.py
@@ -18,6 +18,7 @@ from openagent_eval.datasets.hf_loader import HFDatasetLoader
 from openagent_eval.datasets.json_loader import JSONDatasetLoader
 from openagent_eval.datasets.jsonl_loader import JSONLDatasetLoader
 from openagent_eval.datasets.models import DatasetItemModel, DatasetModel
+from openagent_eval.datasets.pdf_loader import PDFDatasetLoader
 
 __all__ = [
     # Core types
@@ -32,4 +33,5 @@ __all__ = [
     "JSONLDatasetLoader",
     "CSVDatasetLoader",
     "HFDatasetLoader",
+    "PDFDatasetLoader",
 ]

--- a/openagent_eval/datasets/factory.py
+++ b/openagent_eval/datasets/factory.py
@@ -9,28 +9,31 @@ from pathlib import Path
 from typing import Any
 
 from openagent_eval.config.models import DatasetConfig
-from openagent_eval.datasets.base import DatasetLoader
-from openagent_eval.datasets.csv_loader import CsvDatasetLoader
-from openagent_eval.datasets.json_loader import JsonDatasetLoader
-from openagent_eval.datasets.jsonl_loader import JsonlDatasetLoader
+from openagent_eval.datasets.base import BaseDatasetLoader
+from openagent_eval.datasets.csv_loader import CSVDatasetLoader
+from openagent_eval.datasets.json_loader import JSONDatasetLoader
+from openagent_eval.datasets.jsonl_loader import JSONLDatasetLoader
+from openagent_eval.datasets.pdf_loader import PDFDatasetLoader
 from openagent_eval.exceptions.dataset import InvalidDatasetError
 
 # Map of file extensions to loader classes
-_LOADER_MAP: dict[str, type[DatasetLoader]] = {
-    ".json": JsonDatasetLoader,
-    ".jsonl": JsonlDatasetLoader,
-    ".csv": CsvDatasetLoader,
+_LOADER_MAP: dict[str, type[BaseDatasetLoader]] = {
+    ".json": JSONDatasetLoader,
+    ".jsonl": JSONLDatasetLoader,
+    ".csv": CSVDatasetLoader,
+    ".pdf": PDFDatasetLoader,
 }
 
 # Map of format strings to loader classes
-_FORMAT_MAP: dict[str, type[DatasetLoader]] = {
-    "json": JsonDatasetLoader,
-    "jsonl": JsonlDatasetLoader,
-    "csv": CsvDatasetLoader,
+_FORMAT_MAP: dict[str, type[BaseDatasetLoader]] = {
+    "json": JSONDatasetLoader,
+    "jsonl": JSONLDatasetLoader,
+    "csv": CSVDatasetLoader,
+    "pdf": PDFDatasetLoader,
 }
 
 
-def _get_loader(config: DatasetConfig) -> DatasetLoader:
+def _get_loader(config: DatasetConfig) -> BaseDatasetLoader:
     """Get the appropriate loader based on config.
 
     Format is determined by (in priority order):
@@ -96,8 +99,17 @@ def load_dataset(config: DatasetConfig) -> list[dict[str, Any]]:
     loader = _get_loader(config)
     path = Path(config.path)
 
-    return loader.load(
-        path=path,
-        limit=config.limit,
-        shuffle=config.shuffle,
-    )
+    dataset = loader.load(path=path)
+
+    items = list(dataset.items)
+
+    if config.shuffle:
+        import random
+
+        rng = random.Random(42)
+        rng.shuffle(items)
+
+    if config.limit is not None:
+        items = items[: config.limit]
+
+    return [item.to_dict() for item in items]

--- a/openagent_eval/datasets/pdf_loader.py
+++ b/openagent_eval/datasets/pdf_loader.py
@@ -1,0 +1,250 @@
+"""PDF dataset loader.
+
+This module implements the dataset loader for PDF documents. Text is extracted
+from each page using `pypdf` and each page becomes one dataset item where the
+extracted text is stored as ``context``.
+
+A PDF is a source document rather than a list of questions, so the required
+``question`` field is populated from a configurable template (defaulting to a
+generic instruction). This makes the resulting dataset usable for context and
+retrieval evaluation.
+
+Requires the optional ``pypdf`` dependency:
+
+    pip install openagent-eval[pdf]
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from openagent_eval.datasets.base import BaseDatasetLoader, Dataset, DatasetItem
+from openagent_eval.datasets.models import DatasetItemModel
+from openagent_eval.exceptions import DatasetValidationError, InvalidDatasetError
+
+# Default question used when a PDF page is turned into a dataset item.
+DEFAULT_QUESTION_TEMPLATE = "Answer the user's question using the provided context."
+
+
+class PDFDatasetLoader(BaseDatasetLoader):
+    """Loader for PDF documents.
+
+    Extracts text from each page of a PDF and produces one ``DatasetItem`` per
+    page. The page text becomes the ``context`` and the ``question`` field is
+    filled from ``question_template``.
+
+    Pages that yield no extractable text (e.g. scanned/image-only pages) are
+    skipped. If no text can be extracted from any page, loading fails.
+
+    Requires the ``pypdf`` package:
+
+        pip install openagent-eval[pdf]
+
+    Example:
+        ```python
+        from openagent_eval.datasets import PDFDatasetLoader
+        from pathlib import Path
+
+        loader = PDFDatasetLoader()
+        dataset = loader.load(Path("docs/manual.pdf"))
+        ```
+    """
+
+    def __init__(
+        self,
+        question_template: str | None = None,
+    ) -> None:
+        """Initialize the loader.
+
+        Args:
+            question_template: Template used for the ``question`` field of every
+                generated item. Defaults to a generic instruction when ``None``.
+        """
+        self.question_template = question_template or DEFAULT_QUESTION_TEMPLATE
+
+    def load(self, path: Path) -> Dataset:
+        """Load a dataset from a PDF file.
+
+        Args:
+            path: Path to the PDF file.
+
+        Returns:
+            Loaded Dataset object with one item per extracted page.
+
+        Raises:
+            DatasetNotFoundError: If the file does not exist.
+            InvalidDatasetError: If ``pypdf`` is missing or the PDF cannot be read.
+            DatasetValidationError: If no extractable text is found.
+        """
+        self._validate_path(path)
+
+        try:
+            from pypdf import PdfReader
+        except ImportError as e:
+            raise InvalidDatasetError(
+                message=(
+                    "The 'pypdf' package is required for PDF dataset loading. "
+                    "Install it with: pip install openagent-eval[pdf]"
+                ),
+                dataset_path=str(path),
+                format="pdf",
+            ) from e
+
+        try:
+            reader = PdfReader(str(path))
+        except Exception as e:
+            raise InvalidDatasetError(
+                message=f"Failed to read PDF: {e}",
+                dataset_path=str(path),
+                format="pdf",
+            ) from e
+
+        raw_items = self._extract_raw(reader, path)
+        return self._parse_data(raw_items, path)
+
+    def validate(self, data: Any) -> bool:
+        """Validate that the data conforms to the expected PDF schema.
+
+        Args:
+            data: The data to validate (should be a list of dicts).
+
+        Returns:
+            True if valid.
+
+        Raises:
+            DatasetValidationError: If validation fails.
+        """
+        if not isinstance(data, list):
+            raise DatasetValidationError(
+                message="Dataset must be a list of entries",
+                validation_errors=["Expected list, got " + type(data).__name__],
+            )
+
+        if not data:
+            raise DatasetValidationError(
+                message="Dataset is empty",
+                validation_errors=["No pages found in PDF"],
+            )
+
+        errors: list[str] = []
+        for i, item in enumerate(data):
+            if not isinstance(item, dict):
+                errors.append(f"Item {i}: Expected dict, got {type(item).__name__}")
+                continue
+
+            question = item.get("question")
+            if not isinstance(question, str) or not question.strip():
+                errors.append(f"Item {i}: 'question' must be a non-empty string")
+
+            context = item.get("context")
+            if not isinstance(context, str) or not context.strip():
+                errors.append(f"Item {i}: 'context' must be a non-empty string")
+
+        if errors:
+            raise DatasetValidationError(
+                message=f"Dataset validation failed with {len(errors)} error(s)",
+                validation_errors=errors,
+            )
+
+        return True
+
+    def _extract_raw(self, reader: Any, path: Path) -> list[dict[str, Any]]:
+        """Extract raw item dictionaries from a PDF reader.
+
+        Args:
+            reader: A ``pypdf.PdfReader`` instance.
+            path: Path to the source file (for metadata).
+
+        Returns:
+            List of raw item dictionaries (one per non-empty page).
+
+        Raises:
+            DatasetValidationError: If no extractable text is found.
+        """
+        raw_items: list[dict[str, Any]] = []
+        skipped = 0
+
+        for page_num, page in enumerate(reader.pages, start=1):
+            try:
+                text = page.extract_text() or ""
+            except Exception:
+                text = ""
+            text = text.strip()
+
+            if not text:
+                skipped += 1
+                continue
+
+            raw_items.append(
+                {
+                    "question": self.question_template,
+                    "context": text,
+                    "metadata": {
+                        "source": str(path),
+                        "page": page_num,
+                        "format": "pdf",
+                    },
+                }
+            )
+
+        if not raw_items:
+            raise DatasetValidationError(
+                message="No extractable text found in PDF (all pages empty or image-only).",
+                dataset_path=str(path),
+                validation_errors=[f"Skipped {skipped} empty page(s)"],
+            )
+
+        return raw_items
+
+    def _parse_data(
+        self, raw_items: list[dict[str, Any]], path: Path
+    ) -> Dataset:
+        """Parse raw item dictionaries into a Dataset object.
+
+        Args:
+            raw_items: List of raw item dictionaries.
+            path: Path to the source file (for error reporting).
+
+        Returns:
+            Dataset object.
+
+        Raises:
+            DatasetValidationError: If parsing or validation fails.
+        """
+        self.validate(raw_items)
+
+        items: list[DatasetItem] = []
+        validation_errors: list[str] = []
+
+        for i, raw_item in enumerate(raw_items):
+            try:
+                model = DatasetItemModel(**raw_item)
+                items.append(
+                    DatasetItem(
+                        question=model.question,
+                        ground_truth=model.ground_truth,
+                        context=model.context,
+                        metadata=model.metadata,
+                        contexts=model.contexts,
+                    )
+                )
+            except Exception as e:
+                validation_errors.append(f"Item {i}: {e}")
+
+        if validation_errors:
+            raise DatasetValidationError(
+                message=f"Failed to parse {len(validation_errors)} item(s)",
+                dataset_path=str(path),
+                validation_errors=validation_errors,
+            )
+
+        return Dataset(
+            items=items,
+            name=path.stem,
+            metadata={
+                "source": str(path),
+                "format": "pdf",
+                "pages": len(items),
+            },
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,11 @@ evaluation = [
 datasets = [
     "datasets>=2.0.0",
 ]
+pdf = [
+    "pypdf>=4.0.0",
+]
 all = [
-    "openagent-eval[dev,evaluation,datasets]",
+    "openagent-eval[dev,evaluation,datasets,pdf]",
 ]
 
 [project.scripts]

--- a/tests/unit/test_datasets/test_pdf_loader.py
+++ b/tests/unit/test_datasets/test_pdf_loader.py
@@ -1,0 +1,185 @@
+"""Tests for the PDF dataset loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openagent_eval.datasets.pdf_loader import (
+    DEFAULT_QUESTION_TEMPLATE,
+    PDFDatasetLoader,
+)
+from openagent_eval.exceptions import (
+    DatasetNotFoundError,
+    DatasetValidationError,
+    InvalidDatasetError,
+)
+
+
+def _escape(text: str) -> str:
+    """Escape text for inclusion in a PDF content stream."""
+    return text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+
+def _build_pdf(texts: list[str]) -> bytes:
+    """Build a minimal but valid PDF with one page per entry in ``texts``.
+
+    Each page renders its text via a simple text-show operator so that
+    ``pypdf`` can extract it. Used to avoid committing a binary fixture.
+    """
+    n_pages = len(texts)
+    page_objs = [3 + i for i in range(n_pages)]
+    content_objs = [3 + n_pages + i for i in range(n_pages)]
+    font_obj = 3 + 2 * n_pages
+
+    parts: list[bytes] = []
+    offsets: dict[int, int] = {}
+
+    def add(obj_num: int, body: str) -> None:
+        offsets[obj_num] = sum(len(p) for p in parts)
+        parts.append(f"{obj_num} 0 obj\n{body}\nendobj\n".encode())
+
+    add(1, "<< /Type /Catalog /Pages 2 0 R >>")
+    kids = " ".join(f"{n} 0 R" for n in page_objs)
+    add(2, f"<< /Type /Pages /Kids [{kids}] /Count {n_pages} >>")
+
+    for i, text in enumerate(texts):
+        page_body = (
+            f"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+            f"/Contents {content_objs[i]} 0 R "
+            f"/Resources << /Font << /F1 {font_obj} 0 R >> >> >>"
+        )
+        add(page_objs[i], page_body)
+        stream = f"BT /F1 12 Tf 72 720 Td ({_escape(text)}) Tj ET".encode()
+        content_body = (
+            f"<< /Length {len(stream)} >>\nstream\n".encode() + stream + b"\nendstream"
+        )
+        add(content_objs[i], content_body.decode())
+
+    add(font_obj, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+
+    prefix = b"%PDF-1.4\n"
+    body = b"".join(parts)
+    xref_offset = len(prefix) + len(body)
+
+    xref = b"xref\n0 " + str(font_obj + 1).encode() + b"\n"
+    xref += b"0000000000 65535 f \n"
+    for obj_num in range(1, font_obj + 1):
+        xref += f"{len(prefix) + offsets[obj_num]:010d} 00000 n \n".encode()
+
+    trailer = (
+        f"trailer\n<< /Size {font_obj + 1} /Root 1 0 R >>\n"
+        f"startxref\n{xref_offset}\n%%EOF"
+    ).encode()
+
+    return prefix + body + xref + trailer
+
+
+class TestPDFDatasetLoader:
+    """Tests for PDFDatasetLoader."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        self.loader = PDFDatasetLoader()
+
+    def _write_pdf(self, path: Path, texts: list[str]) -> None:
+        """Helper to write a PDF with the given page texts."""
+        path.write_bytes(_build_pdf(texts))
+
+    def test_load_multi_page_pdf(self, tmp_path: Path) -> None:
+        """Test loading a multi-page PDF produces one item per page."""
+        pdf_path = tmp_path / "doc.pdf"
+        self._write_pdf(pdf_path, ["Page one about Python.", "Page two about RAG."])
+
+        dataset = self.loader.load(pdf_path)
+
+        assert dataset.size == 2
+        assert dataset.name == "doc"
+        assert "Python" in dataset[0].context
+        assert "RAG" in dataset[1].context
+        assert dataset[0].metadata["page"] == 1
+        assert dataset[1].metadata["page"] == 2
+        assert dataset.metadata["format"] == "pdf"
+        assert dataset.metadata["pages"] == 2
+
+    def test_load_single_page_pdf(self, tmp_path: Path) -> None:
+        """Test loading a single-page PDF."""
+        pdf_path = tmp_path / "single.pdf"
+        self._write_pdf(pdf_path, ["Only page content."])
+
+        dataset = self.loader.load(pdf_path)
+
+        assert dataset.size == 1
+        assert dataset[0].context == "Only page content."
+        assert dataset[0].question == DEFAULT_QUESTION_TEMPLATE
+
+    def test_load_uses_custom_question_template(self, tmp_path: Path) -> None:
+        """Test that a custom question template is applied."""
+        loader = PDFDatasetLoader(question_template="Summarize this page.")
+        pdf_path = tmp_path / "doc.pdf"
+        self._write_pdf(pdf_path, ["Content here."])
+
+        dataset = loader.load(pdf_path)
+
+        assert dataset[0].question == "Summarize this page."
+
+    def test_load_file_not_found(self, tmp_path: Path) -> None:
+        """Test loading a non-existent file raises DatasetNotFoundError."""
+        pdf_path = tmp_path / "missing.pdf"
+
+        with pytest.raises(DatasetNotFoundError):
+            self.loader.load(pdf_path)
+
+    def test_load_empty_pdf_raises(self, tmp_path: Path) -> None:
+        """Test that a PDF with no extractable text raises."""
+        pdf_path = tmp_path / "blank.pdf"
+        # A PDF with a page that has no text content stream.
+        self._write_pdf(pdf_path, [])
+
+        with pytest.raises(DatasetValidationError):
+            self.loader.load(pdf_path)
+
+    def test_load_missing_pypdf_raises(self, tmp_path: Path, monkeypatch) -> None:
+        """Test that a helpful error is raised when pypdf is missing."""
+        import sys
+
+        pdf_path = tmp_path / "doc.pdf"
+        self._write_pdf(pdf_path, ["Content."])
+        monkeypatch.setitem(sys.modules, "pypdf", None)
+
+        with pytest.raises(InvalidDatasetError, match="pypdf"):
+            self.loader.load(pdf_path)
+
+    def test_validate_valid_data(self) -> None:
+        """Test validate with valid data."""
+        data = [
+            {"question": "Q1", "context": "C1"},
+            {"question": "Q2", "context": "C2"},
+        ]
+        assert self.loader.validate(data) is True
+
+    def test_validate_not_list(self) -> None:
+        """Test validate with non-list data."""
+        with pytest.raises(DatasetValidationError):
+            self.loader.validate("not a list")
+
+    def test_validate_empty_list(self) -> None:
+        """Test validate with empty list."""
+        with pytest.raises(DatasetValidationError):
+            self.loader.validate([])
+
+    def test_validate_missing_context(self) -> None:
+        """Test validate rejects items without context."""
+        data = [{"question": "Q1"}]
+        with pytest.raises(DatasetValidationError):
+            self.loader.validate(data)
+
+    def test_factory_registration(self) -> None:
+        """Test that the PDF loader is registered in the factory maps."""
+        from openagent_eval.datasets.factory import _FORMAT_MAP, _LOADER_MAP
+
+        assert ".pdf" in _LOADER_MAP
+        assert "pdf" in _FORMAT_MAP
+        assert _LOADER_MAP[".pdf"] is PDFDatasetLoader
+        assert _FORMAT_MAP["pdf"] is PDFDatasetLoader


### PR DESCRIPTION
## Summary

Adds a `PDFDatasetLoader` to the `datasets` module so PDF documents become a supported dataset source for RAG evaluation.

- Extracts text **per page** using `pypdf` (optional `pdf` extra) and turns each page into a `DatasetItem` with the page text as `context`.
- The required `question` field is populated from a configurable `question_template` (default: a generic instruction), since a PDF is a source document rather than a Q&A list.
- Skips pages with no extractable text; raises `DatasetValidationError` when nothing is extractable (e.g. scanned/image-only PDFs).
- Gracefully raises a helpful `InvalidDatasetError` when `pypdf` is not installed.

## Motivation

The framework supported JSON, JSONL, CSV, and HuggingFace datasets, but not PDFs — a common knowledge-source format for RAG corpora. This lets users evaluate directly against PDF documents.

## Files Modified

- `openagent_eval/datasets/pdf_loader.py` - New `PDFDatasetLoader` (BaseDatasetLoader implementation)
- `openagent_eval/datasets/__init__.py` - Export `PDFDatasetLoader`
- `openagent_eval/datasets/factory.py` - Register `.pdf`/`pdf`; fix pre-existing `DatasetLoader` import and wrong-cased loader names; fix `load()` call signature (limit/shuffle now applied to the returned Dataset)
- `openagent_eval/cli/utils/helpers.py` - `load_dataset_for_run` now auto-detects format via the factory and returns `list[dict]` (matches `engine.run`); previously returned a `Dataset`, which was a bug
- `pyproject.toml` - Add optional `pdf = ["pypdf>=4.0.0"]` extra
- `tests/unit/test_datasets/test_pdf_loader.py` - 11 unit tests
- `.ai/03_CONTEXT.md`, `.ai/05_TASKS.md` - Track the new loader

## Architectural Decisions

- Chose `pypdf` as a pure-Python, framework-agnostic dependency consistent with the project's "pure Python framework" philosophy and its optional-extra pattern (like the `datasets` extra).
- Per-page extraction keeps items granular and maps naturally to retrieval/context evaluation.

## Breaking Changes

None. The `load_dataset_for_run` return-type fix (Dataset -> list[dict]) corrects a pre-existing bug and aligns with `engine.run`'s expected `list[dict]` input.

## Testing

- 11 new PDF loader unit tests (load, multi/single page, custom template, missing file, empty PDF, missing pypdf, validation, factory registration).
- Full relevant suite: 332 passed (datasets, cli, core, metrics, reports, plugins). Provider tests are excluded only due to a missing optional `tiktoken` dependency in the environment (pre-existing, unrelated).

## Remaining TODOs

None.

## Assumptions & Limitations

- PDFs must contain extractable (text-layer) content; image-only/scanned PDFs require OCR and are not supported by this loader.
- Each page becomes a single item; chunk-level splitting (by size) was intentionally left out to keep the loader simple.
