### PR TITLE
Potential fix for code scanning alert no. 1: Jinja2 templating with autoescape=False

### DIFF
--- a/openagent_eval/reports/html.py
+++ b/openagent_eval/reports/html.py
@@ -73,10 +73,11 @@ class HTMLReport(ReportGenerator):
         Raises:
             ImportError: If jinja2 is not installed.
         """
-        from jinja2 import Template
+        from jinja2 import Environment, select_autoescape
 
         template_str = self._load_template()
-        template = Template(template_str)
+        env = Environment(autoescape=select_autoescape(["html", "xml"]))
+        template = env.from_string(template_str)
         return template.render(**context)
 
     def generate(self, report: Any) -> str:


### PR DESCRIPTION
Potential fix for [https://github.com/OpenAgentHQ/openagent-eval/security/code-scanning/1](https://github.com/OpenAgentHQ/openagent-eval/security/code-scanning/1)

To fix this safely without changing intended functionality, replace direct `Template(template_str)` usage with a Jinja2 `Environment` configured with `autoescape=select_autoescape(["html", "xml"])`, then compile the template string via `env.from_string(...)`.

Best concrete fix in `openagent_eval/reports/html.py`:
- In `_render_template`, change the local import from `Template` to `Environment, select_autoescape`.
- Build an environment with autoescape enabled for HTML/XML.
- Create the template from the loaded string using `env.from_string(template_str)`.
- Render with the same context as before.

This preserves existing behavior (loading template text from file/string and rendering it) while enforcing escaping appropriate for HTML output.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
