### PR TITLE
Fix for Statement has no effect

### DIFF
--- a/openagent_eval/providers/base/llm.py
+++ b/openagent_eval/providers/base/llm.py
@@ -80,7 +80,7 @@ class LLMProvider(ABC):
         Raises:
             ProviderError: If token counting fails.
         """
-        ...
+        pass
 
     def validate_inputs(self, **kwargs: Any) -> None:  # noqa: B027
         """Validate provider inputs before execution.


### PR DESCRIPTION
To fix this cleanly without changing functionality, replace the ellipsis statement in the abstract method body with `pass`. For abstract methods, `pass` is the idiomatic no-op and is not flagged as a useless expression statement.

Specifically in `openagent_eval/providers/base/llm.py`, update the `get_token_count` abstract method body (line 83 in the provided snippet) from `...` to `pass`. No imports, helper methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._