### PR TITLE
fix: resolve dataset path config and undeclared provider dependencies

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,27 @@
+# OpenAgent Eval Configuration
+# See documentation for options: https://github.com/OpenAgentHQ/openagent-eval
+
+dataset:
+  path: data/sample_questions.json
+  format: json
+  # limit: 100
+
+llm:
+  provider: openai
+  model: gpt-4o-mini
+  temperature: 0.0
+
+retrieval:
+  # provider: chromadb
+  # collection_name: my_collection
+
+evaluation:
+  metrics:
+    - answer_relevancy
+    - faithfulness
+    - context_precision
+    - context_recall
+
+report:
+  output: terminal
+  output_dir: ./reports

--- a/data/sample_questions.json
+++ b/data/sample_questions.json
@@ -1,0 +1,49 @@
+{
+  "items": [
+    {
+      "question": "What is RAG (Retrieval-Augmented Generation)?",
+      "ground_truth": "RAG is a technique that combines retrieval of relevant documents with text generation by a language model to produce more accurate and grounded answers.",
+      "ground_truth_contexts": [
+        "Retrieval-Augmented Generation (RAG) is a technique that enhances large language models by retrieving relevant documents from an external knowledge base before generating a response.",
+        "RAG combines two key components: a retriever that searches for relevant information, and a generator that produces answers based on the retrieved context.",
+        "The main advantage of RAG is that it grounds the language model's responses in factual, up-to-date information rather than relying solely on training data."
+      ]
+    },
+    {
+      "question": "What is the difference between precision and recall in information retrieval?",
+      "ground_truth": "Precision measures the fraction of retrieved documents that are relevant, while recall measures the fraction of all relevant documents that were retrieved.",
+      "ground_truth_contexts": [
+        "Precision is the ratio of relevant documents retrieved to the total number of documents retrieved. It measures how many of the retrieved items are actually relevant.",
+        "Recall is the ratio of relevant documents retrieved to the total number of relevant documents in the collection. It measures how many of the relevant items were found.",
+        "The precision-recall tradeoff is a fundamental concept in information retrieval: increasing precision often decreases recall and vice versa."
+      ]
+    },
+    {
+      "question": "What are vector embeddings and how are they used in semantic search?",
+      "ground_truth": "Vector embeddings are numerical representations of text that capture semantic meaning, enabling similarity-based search rather than keyword matching.",
+      "ground_truth_contexts": [
+        "Vector embeddings are dense numerical vectors that represent the semantic meaning of text in a high-dimensional space.",
+        "In semantic search, both queries and documents are converted to embeddings, and similar vectors indicate semantically related content.",
+        "Popular embedding models include sentence-transformers, OpenAI embeddings, and Cohere embeddings, each producing vectors of different dimensions."
+      ]
+    },
+    {
+      "question": "What is a chunking strategy in RAG and why does it matter?",
+      "ground_truth": "Chunking strategies determine how documents are split into smaller pieces for embedding and retrieval, affecting both retrieval quality and context relevance.",
+      "ground_truth_contexts": [
+        "Chunking is the process of splitting large documents into smaller, manageable pieces that can be individually embedded and retrieved.",
+        "Common chunking strategies include fixed-size, sentence-based, paragraph-based, and semantic chunking, each with different tradeoffs.",
+        "The choice of chunking strategy significantly impacts retrieval quality: too small chunks may lack context, while too large chunks may introduce noise."
+      ]
+    },
+    {
+      "question": "What is token counting and why is it important for LLM cost estimation?",
+      "ground_truth": "Token counting measures the number of tokens in text, which is essential for estimating API costs since most LLM providers charge per token.",
+      "ground_truth_contexts": [
+        "Tokens are the basic units that language models process. A token is roughly 4 characters or 0.75 words in English.",
+        "LLM providers typically charge based on token usage, with separate rates for input (prompt) and output (completion) tokens.",
+        "Accurate token counting is crucial for budget management in production RAG systems, as it directly impacts API costs."
+      ]
+    }
+  ]
+}

--- a/openagent_eval/datasets/factory.py
+++ b/openagent_eval/datasets/factory.py
@@ -60,8 +60,19 @@ def _get_loader(config: DatasetConfig) -> BaseDatasetLoader:
             format=config.format,
         )
 
+    # Guard against directory paths, which have no usable extension and
+    # would otherwise surface a misleading "set the format field" error.
+    path = Path(config.path)
+    if path.is_dir():
+        raise InvalidDatasetError(
+            message=f"Dataset path '{config.path}' is a directory, not a file. "
+            f"Point 'path' to a dataset file (e.g. data/sample_questions.json) "
+            f"or set the 'format' field explicitly in your config.",
+            dataset_path=config.path,
+        )
+
     # Fall back to file extension
-    ext = Path(config.path).suffix.lower()
+    ext = path.suffix.lower()
     if ext in _LOADER_MAP:
         return _LOADER_MAP[ext]()
 

--- a/openagent_eval/datasets/json_loader.py
+++ b/openagent_eval/datasets/json_loader.py
@@ -67,6 +67,14 @@ class JSONDatasetLoader(BaseDatasetLoader):
                 line_number=e.lineno,
             ) from e
 
+        # Support both a top-level array and the common {"items": [...]} wrapper.
+        if (
+            isinstance(raw_data, dict)
+            and "items" in raw_data
+            and isinstance(raw_data["items"], list)
+        ):
+            raw_data = raw_data["items"]
+
         return self._parse_data(raw_data, path)
 
     def validate(self, data: Any) -> bool:

--- a/openagent_eval/providers/llm/anthropic.py
+++ b/openagent_eval/providers/llm/anthropic.py
@@ -12,10 +12,14 @@ import os
 import time
 from typing import Any
 
-import anthropic
+try:
+    import anthropic
+except ImportError:
+    anthropic = None
 
 from openagent_eval.exceptions.provider import (
     ProviderConnectionError,
+    ProviderError,
     ProviderExecutionError,
 )
 from openagent_eval.providers.base.llm import LLMProvider
@@ -106,6 +110,16 @@ class Anthropic(LLMProvider):
         self.model = model
         self.temperature = temperature
         self.max_tokens = max_tokens
+
+        if anthropic is None:
+            raise ProviderError(
+                message=(
+                    "The 'anthropic' package is required for the Anthropic provider. "
+                    "Install with: pip install openagent-eval[providers]"
+                ),
+                provider_name="anthropic",
+            )
+
         self._client = anthropic.AsyncAnthropic(api_key=api_key)
 
     async def generate(self, prompt: str, **kwargs: Any) -> str:

--- a/openagent_eval/providers/llm/gemini.py
+++ b/openagent_eval/providers/llm/gemini.py
@@ -23,21 +23,22 @@ from typing import Any
 
 from openagent_eval.exceptions.provider import (
     ProviderConnectionError,
+    ProviderError,
     ProviderExecutionError,
 )
 from openagent_eval.providers.base.llm import LLMProvider
 from openagent_eval.providers.models import LLMResponse, TokenUsage
 
-# google-genai SDK imports (current, non-deprecated SDK)
+# google-genai SDK imports (current, non-deprecated SDK). Imported lazily so
+# the module can be imported without the optional dependency installed.
 try:
     from google import genai
     from google.genai import errors as genai_errors
     from google.genai import types
-except ImportError as exc:
-    raise ImportError(
-        "google-genai package is required for Gemini provider. "
-        "Install it with: pip install google-genai"
-    ) from exc
+except ImportError:
+    genai = None
+    genai_errors = None
+    types = None
 
 import httpx
 
@@ -113,6 +114,15 @@ class Gemini(LLMProvider):
         self._model = model
         self._temperature = temperature
         self._max_tokens = max_tokens
+
+        if genai is None:
+            raise ProviderError(
+                message=(
+                    "The 'google-genai' package is required for the Gemini provider. "
+                    "Install with: pip install openagent-eval[providers]"
+                ),
+                provider_name=self.name,
+            )
 
         try:
             self._client = genai.Client(api_key=resolved_api_key)

--- a/openagent_eval/providers/llm/groq.py
+++ b/openagent_eval/providers/llm/groq.py
@@ -14,10 +14,14 @@ import os
 import time
 from typing import Any
 
-import groq
+try:
+    import groq
+except ImportError:
+    groq = None
 
 from openagent_eval.exceptions.provider import (
     ProviderConnectionError,
+    ProviderError,
     ProviderExecutionError,
 )
 from openagent_eval.providers.base.llm import LLMProvider
@@ -116,6 +120,15 @@ class Groq(LLMProvider):
         self.model = model
         self.temperature = temperature
         self.max_tokens = max_tokens
+
+        if groq is None:
+            raise ProviderError(
+                message=(
+                    "The 'groq' package is required for the Groq provider. "
+                    "Install with: pip install openagent-eval[providers]"
+                ),
+                provider_name="groq",
+            )
 
         try:
             self.client = groq.AsyncGroq(api_key=api_key)

--- a/openagent_eval/providers/llm/openai.py
+++ b/openagent_eval/providers/llm/openai.py
@@ -36,11 +36,16 @@ import os
 import time
 from typing import TYPE_CHECKING, Any
 
-import tiktoken
-from openai import AsyncOpenAI
+try:
+    import tiktoken
+    from openai import AsyncOpenAI
+except ImportError:
+    tiktoken = None
+    AsyncOpenAI = None
 
 from openagent_eval.exceptions.provider import (
     ProviderConnectionError,
+    ProviderError,
     ProviderExecutionError,
 )
 from openagent_eval.providers.base.llm import LLMProvider
@@ -116,6 +121,15 @@ class OpenAIProvider(LLMProvider):
         if not self._api_key:
             raise ProviderConnectionError(
                 message="OpenAI API key not provided. Set OPENAI_API_KEY environment variable or pass api_key parameter.",
+                provider_name=self.name,
+            )
+
+        if AsyncOpenAI is None:
+            raise ProviderError(
+                message=(
+                    "The 'openai' and 'tiktoken' packages are required for the "
+                    "OpenAI provider. Install with: pip install openagent-eval[providers]"
+                ),
                 provider_name=self.name,
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,17 @@ datasets = [
 pdf = [
     "pypdf>=4.0.0",
 ]
+# --- LLM provider extras ------------------------------------------------
+# These SDKs are imported unconditionally by their respective provider
+# adapters (openagent_eval/providers/llm/*), so they must be installed to
+# use that provider.
+providers = [
+    "openai>=1.0.0",
+    "anthropic>=0.40.0",
+    "groq>=0.4.0",
+    "google-genai>=0.1.0",
+    "tiktoken>=0.5.0",
+]
 # --- Retriever provider extras -------------------------------------------
 qdrant = ["qdrant-client>=1.7.0"]
 pinecone = ["pinecone-client>=2.2.0"]
@@ -66,7 +77,7 @@ pgvector = ["psycopg[binary]>=3.1.0", "pgvector>=0.2.0"]
 elasticsearch = ["elasticsearch>=8.0.0"]
 bm25 = ["rank-bm25>=0.2.0"]
 all = [
-    "openagent-eval[dev,evaluation,datasets,pdf,qdrant,pinecone,weaviate,faiss,pgvector,elasticsearch,bm25]",
+    "openagent-eval[dev,evaluation,datasets,pdf,providers,qdrant,pinecone,weaviate,faiss,pgvector,elasticsearch,bm25]",
 ]
 
 [project.scripts]

--- a/tests/unit/test_providers/test_anthropic.py
+++ b/tests/unit/test_providers/test_anthropic.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import httpx
+
 # Skip tests if anthropic is not installed
 anthropic = pytest.importorskip("anthropic", reason="anthropic not installed")
 


### PR DESCRIPTION
## Summary

- **Dataset config bug**: \config.yaml\ pointed \dataset.path\ at a non-existent \data/questions.json\ (and a bare directory \data/\ produced a misleading \InvalidDatasetError\). Now points to the existing \data/sample_questions.json\ with an explicit \ormat: json\.
- **Clearer loader errors**: \datasets/factory.py\ now detects directory paths and raises an actionable error instead of the misleading \set the format field\ message.
- **JSON loader**: supports the common \{\items\: [...]}\ wrapper so \sample_questions.json\ loads (5 items).
- **Undeclared dependencies**: LLM provider SDKs (\openai\, \nthropic\, \groq\, \google-genai\, \	iktoken\) were imported unconditionally but never declared. Added a \providers\ optional extra in \pyproject.toml\ (and to \ll\).
- **Lazy provider imports**: the four LLM provider modules now import their SDKs lazily (guarded \	ry/except\), so the modules import without the optional dependency and raise a clear \ProviderError\ with install instructions at instantiation — matching the project's existing lazy-import design.
- **Test fix**: added the missing \import httpx\ in \	est_anthropic.py\ (was using \httpx.Response\ unimported → 3 NameError failures).

## Test plan

- Full suite: **526 passed, 3 skipped** (no regressions).
- Verified provider modules import cleanly without their SDK and raise \ProviderError: The '<sdk>' package is required ... Install with: pip install openagent-eval[providers]\ when instantiated without it.

## Notes

Only files related to this fix were committed; pre-existing unrelated modifications (e.g. README.md) and untracked artifacts (reports/, docs) were left out.