### PR TITLE
docs: add provider guides and examples

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,46 @@
+# Examples
+
+Worked examples showing how to use OpenAgent Eval in practice.
+
+## RAG Evaluation Tutorial
+
+A hands-on Jupyter notebook that walks through a complete RAG evaluation:
+
+- Loading a dataset
+- Configuring an LLM and retriever
+- Running retrieval and generation metrics
+- Interpreting the results
+
+**Download:** [`rag_evaluation_tutorial.ipynb`](https://github.com/OpenAgentHQ/openagent-eval/blob/main/examples/rag_evaluation_tutorial.ipynb)
+
+### What you'll learn
+
+| Section | Topic |
+|---------|-------|
+| 1 | Setting up the environment and config |
+| 2 | Loading and inspecting a dataset |
+| 3 | Configuring LLM providers (OpenAI, Ollama, Mock) |
+| 4 | Configuring retriever providers (Chroma, Memory, BM25) |
+| 5 | Running the evaluation pipeline |
+| 6 | Understanding retrieval metrics (precision, recall, MRR, NDCG) |
+| 7 | Understanding generation metrics (faithfulness, relevancy, hallucination) |
+| 8 | Running all 18 metrics together |
+| 9 | Interpreting the report output |
+
+### Prerequisites
+
+```bash
+pip install openagent-eval jupyter
+```
+
+### Quick start
+
+```bash
+cd examples/
+jupyter notebook rag_evaluation_tutorial.ipynb
+```
+
+## More examples
+
+See the [scripts/](https://github.com/OpenAgentHQ/openagent-eval/tree/main/scripts) directory
+in the repository for additional runnable examples.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,11 +147,40 @@ nav:
   - Getting Started:
       - Installation: installation.md
       - Quickstart: quickstart.md
+  - Providers:
+      - providers/index.md
+      - LLM:
+          - providers/llm/index.md
+          - OpenAI: providers/llm/openai.md
+          - Anthropic: providers/llm/anthropic.md
+          - Gemini: providers/llm/gemini.md
+          - Groq: providers/llm/groq.md
+          - OpenRouter: providers/llm/openrouter.md
+          - Ollama: providers/llm/ollama.md
+          - Mock: providers/llm/mock.md
+      - Retrievers:
+          - providers/retrievers/index.md
+          - Chroma: providers/retrievers/chroma.md
+          - Qdrant: providers/retrievers/qdrant.md
+          - Pinecone: providers/retrievers/pinecone.md
+          - Weaviate: providers/retrievers/weaviate.md
+          - FAISS: providers/retrievers/faiss.md
+          - PGVector: providers/retrievers/pgvector.md
+          - Elasticsearch: providers/retrievers/elasticsearch.md
+          - BM25: providers/retrievers/bm25.md
+          - Memory: providers/retrievers/memory.md
+          - HTTP: providers/retrievers/http.md
+          - Mock: providers/retrievers/mock.md
+      - Embedders:
+          - providers/embedders/index.md
+          - Sentence Transformers: providers/embedders/sentence_transformers.md
+          - Mock: providers/embedders/mock.md
   - Guide:
       - Architecture: architecture.md
       - CLI Reference: cli.md
       - API Reference: api.md
-      - Examples: examples.md
+  - Examples:
+      - examples/index.md
   - Community:
       - Contributing: contributing.md
       - Roadmap: roadmap.md


### PR DESCRIPTION
## Summary

- 20 per-provider guide pages (7 LLM, 11 Retriever, 2 Embedder)
- Providers overview page with comparison matrices
- Examples section with RAG evaluation tutorial guide
- Full Providers navigation in mkdocs.yml

## Changes

### Provider Guides
- LLM: OpenAI, Anthropic, Gemini, Groq, OpenRouter, Ollama, Mock
- Retrievers: Chroma, Qdrant, Pinecone, Weaviate, FAISS, PGVector, Elasticsearch, BM25, Memory, HTTP, Mock
- Embedders: Sentence Transformers, Mock

### Fixes
- Fix GOOGLE_API_KEY → GEMINI_API_KEY in installation.md
- Fix CLI syntax (--config → positional) in 12_retrievers.md
- Add provider cross-links in quickstart.md, index.md, 12_retrievers.md

### Examples
- docs/examples/index.md with RAG tutorial overview and download link

## Validation
- mkdocs build --strict passes with zero warnings