### PR TITLE
feat: Phase 10 - LLM-as-Judge Metrics (NLI-based scoring)

### DIFF
--- a/openagent_eval/metrics/__init__.py
+++ b/openagent_eval/metrics/__init__.py
@@ -3,6 +3,7 @@
 This package provides all evaluation metrics organized by category:
 - Retrieval metrics: Context precision, recall, MRR, NDCG, etc.
 - Generation metrics: Faithfulness, relevancy, hallucination, BLEU, ROUGE, etc.
+- NLI metrics: NLI-based scoring for faithfulness and relevancy
 - Performance metrics: Latency tracking
 - Cost metrics: Token counting and cost estimation
 
@@ -19,8 +20,20 @@ from openagent_eval.metrics.generation import (
     F1Score,
     Faithfulness,
     HallucinationDetection,
+    LLMJudgeMetric,
+    AsyncLLMJudgeMetric,
+    JudgeCriteria,
     ROUGE,
     SemanticSimilarity,
+)
+from openagent_eval.metrics.nli import (
+    NLIJudge,
+    NLIResult,
+    NLILabel,
+    ClaimExtractor,
+    Claim,
+    EvidenceFinder,
+    EvidenceMatch,
 )
 from openagent_eval.metrics.performance import LatencyMetric
 from openagent_eval.metrics.retrieval import (
@@ -53,8 +66,19 @@ __all__ = [
     "F1Score",
     "Faithfulness",
     "HallucinationDetection",
+    "LLMJudgeMetric",
+    "AsyncLLMJudgeMetric",
+    "JudgeCriteria",
     "ROUGE",
     "SemanticSimilarity",
+    # NLI
+    "NLIJudge",
+    "NLIResult",
+    "NLILabel",
+    "ClaimExtractor",
+    "Claim",
+    "EvidenceFinder",
+    "EvidenceMatch",
     # Performance
     "LatencyMetric",
     # Cost

--- a/openagent_eval/metrics/generation/__init__.py
+++ b/openagent_eval/metrics/generation/__init__.py
@@ -10,6 +10,14 @@ from openagent_eval.metrics.generation.exact_match import ExactMatch
 from openagent_eval.metrics.generation.f1 import F1Score
 from openagent_eval.metrics.generation.faithfulness import Faithfulness
 from openagent_eval.metrics.generation.hallucination import HallucinationDetection
+from openagent_eval.metrics.generation.llm_judge import (
+    LLMJudgeMetric,
+    AsyncLLMJudgeMetric,
+    JudgeCriteria,
+    FAITHFULNESS_CRITERIA,
+    RELEVANCY_CRITERIA,
+    COMPREHENSIVENESS_CRITERIA,
+)
 from openagent_eval.metrics.generation.relevancy import AnswerRelevancy
 from openagent_eval.metrics.generation.rouge import ROUGE
 from openagent_eval.metrics.generation.similarity import SemanticSimilarity
@@ -18,10 +26,16 @@ __all__ = [
     "AnswerRelevancy",
     "BERTScore",
     "BLEU",
+    "COMPREHENSIVENESS_CRITERIA",
     "ExactMatch",
     "F1Score",
+    "FAITHFULNESS_CRITERIA",
     "Faithfulness",
     "HallucinationDetection",
+    "LLMJudgeMetric",
+    "AsyncLLMJudgeMetric",
+    "JudgeCriteria",
+    "RELEVANCY_CRITERIA",
     "ROUGE",
     "SemanticSimilarity",
 ]

--- a/openagent_eval/metrics/generation/faithfulness.py
+++ b/openagent_eval/metrics/generation/faithfulness.py
@@ -1,12 +1,15 @@
 """Faithfulness metric.
 
 Measures whether the generated answer is grounded in the provided contexts.
-Uses Ragas faithfulness score when available, falls back to simple overlap.
+Uses Ragas faithfulness score when available, falls back to NLI-based scoring,
+and finally to simple word overlap as last resort.
 """
 
 from __future__ import annotations
 
 from typing import Any
+
+from loguru import logger
 
 from openagent_eval.metrics.base import BaseMetric, MetricResult
 
@@ -17,6 +20,11 @@ class Faithfulness(BaseMetric):
     Faithfulness = |claims supported by context| / |total claims|
 
     A score of 1.0 means all claims in the answer are supported by contexts.
+
+    Scoring priority:
+    1. Ragas (if available) — most accurate
+    2. NLI-based (if transformers available) — accurate claim verification
+    3. Simple word overlap — fast fallback
     """
 
     name = "faithfulness"
@@ -55,6 +63,12 @@ class Faithfulness(BaseMetric):
         except ImportError:
             pass
 
+        # Try NLI-based scoring if available
+        try:
+            return self._evaluate_with_nli(answer, contexts)
+        except (ImportError, Exception) as e:
+            logger.debug("NLI scoring unavailable, using simple overlap: {}", e)
+
         # Fallback: simple word overlap
         return self._evaluate_simple(answer, contexts)
 
@@ -87,6 +101,42 @@ class Faithfulness(BaseMetric):
             score=score,
             reason=f"Ragas faithfulness: {score:.4f}",
             metadata={"method": "ragas"},
+        )
+
+    def _evaluate_with_nli(
+        self, answer: str, contexts: list[str]
+    ) -> MetricResult:
+        """Evaluate using NLI-based claim verification."""
+        from openagent_eval.metrics.nli import ClaimExtractor, EvidenceFinder, NLIJudge
+
+        judge = NLIJudge()
+        extractor = ClaimExtractor()
+        finder = EvidenceFinder(judge)
+
+        claims = extractor.extract(answer)
+        if not claims:
+            return MetricResult(
+                score=1.0,
+                reason="No claims to verify (empty or unstructured answer)",
+                metadata={"method": "nli", "claims_total": 0, "claims_supported": 0},
+            )
+
+        score, matches = finder.score_faithfulness(claims, contexts)
+
+        supported = sum(
+            1 for m in matches
+            if m is not None and m.nli_result.entailed_score >= 0.5
+        )
+
+        return MetricResult(
+            score=score,
+            reason=f"NLI faithfulness: {supported}/{len(claims)} claims supported",
+            metadata={
+                "method": "nli",
+                "claims_total": len(claims),
+                "claims_supported": supported,
+                "model": judge._model_name,
+            },
         )
 
     def _evaluate_simple(

--- a/openagent_eval/metrics/generation/llm_judge.py
+++ b/openagent_eval/metrics/generation/llm_judge.py
@@ -1,0 +1,238 @@
+"""Generic LLM-as-Judge metric for custom quality dimensions.
+
+Provides a flexible metric that uses an LLM to evaluate any custom
+quality dimension, returning a score based on LLM judgment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from loguru import logger
+
+from openagent_eval.metrics.base import BaseMetric, MetricResult
+from openagent_eval.providers.base.llm import LLMProvider
+
+
+@dataclass(frozen=True)
+class JudgeCriteria:
+    """Criteria for LLM-as-Judge evaluation.
+
+    Attributes:
+        name: Name of the quality dimension.
+        description: What this criteria measures.
+        scoring_prompt: Template prompt for scoring. Use {premise} and {hypothesis}.
+        passing_threshold: Minimum score to consider passing.
+    """
+
+    name: str
+    description: str
+    scoring_prompt: str
+    passing_threshold: float = 0.7
+
+
+# Pre-defined criteria templates
+FAITHFULNESS_CRITERIA = JudgeCriteria(
+    name="faithfulness",
+    description="Whether the answer is supported by the context",
+    scoring_prompt=(
+        "Rate how well the following answer is supported by the context. "
+        "Score from 0.0 (not supported at all) to 1.0 (fully supported).\n\n"
+        "Context: {premise}\n\n"
+        "Answer: {hypothesis}\n\n"
+        "Score:"
+    ),
+)
+
+RELEVANCY_CRITERIA = JudgeCriteria(
+    name="relevancy",
+    description="Whether the answer addresses the question",
+    scoring_prompt=(
+        "Rate how well the following answer addresses the question. "
+        "Score from 0.0 (completely irrelevant) to 1.0 (fully addresses the question).\n\n"
+        "Question: {premise}\n\n"
+        "Answer: {hypothesis}\n\n"
+        "Score:"
+    ),
+)
+
+COMPREHENSIVENESS_CRITERIA = JudgeCriteria(
+    name="comprehensiveness",
+    description="How comprehensive and thorough the answer is",
+    scoring_prompt=(
+        "Rate how comprehensive and thorough the following answer is. "
+        "Consider whether it covers all important aspects. "
+        "Score from 0.0 (very incomplete) to 1.0 (fully comprehensive).\n\n"
+        "Topic: {premise}\n\n"
+        "Answer: {hypothesis}\n\n"
+        "Score:"
+    ),
+)
+
+
+class LLMJudgeMetric(BaseMetric):
+    """Generic LLM-as-Judge metric for custom quality dimensions.
+
+    Uses an LLM provider to evaluate any custom quality criteria.
+    The LLM receives a scoring prompt and returns a numeric score.
+
+    Example:
+        ```python
+        from openagent_eval.metrics.generation.llm_judge import (
+            LLMJudgeMetric, FAITHFULNESS_CRITERIA
+        )
+
+        judge = LLMJudgeMetric(
+            provider=openai_provider,
+            criteria=FAITHFULNESS_CRITERIA,
+        )
+        result = judge.evaluate(
+            premise="The sky is blue.",
+            hypothesis="The sky is indeed blue and clear."
+        )
+        ```
+    """
+
+    def __init__(
+        self,
+        provider: LLMProvider,
+        criteria: JudgeCriteria | None = None,
+    ) -> None:
+        """Initialize the LLM judge metric.
+
+        Args:
+            provider: LLM provider for scoring.
+            criteria: Scoring criteria. Defaults to faithfulness.
+        """
+        self._provider = provider
+        self._criteria = criteria or FAITHFULNESS_CRITERIA
+        self.name = f"llm_judge_{self._criteria.name}"
+        self.description = self._criteria.description
+
+    def evaluate(self, **kwargs: Any) -> MetricResult:
+        """Evaluate using LLM judge.
+
+        Args:
+            premise: The context or question.
+            hypothesis: The answer or text to evaluate.
+
+        Returns:
+            MetricResult with LLM-judged score.
+        """
+        premise = kwargs.get("premise", "")
+        hypothesis = kwargs.get("hypothesis", "")
+
+        if not premise or not hypothesis:
+            return MetricResult(
+                score=0.0,
+                reason="Missing premise or hypothesis",
+                metadata={"method": "llm_judge", "criteria": self._criteria.name},
+            )
+
+        # Build prompt
+        prompt = self._criteria.scoring_prompt.format(
+            premise=premise, hypothesis=hypothesis
+        )
+
+        try:
+            import asyncio
+            import inspect
+
+            response = self._provider.generate(prompt)
+            # Handle both sync and async providers
+            if inspect.iscoroutine(response):
+                response = asyncio.get_event_loop().run_until_complete(response)
+            score = self._parse_score(response)
+        except Exception as e:
+            logger.error("LLM judge failed: {}", e)
+            return MetricResult(
+                score=0.0,
+                reason=f"LLM judge failed: {e}",
+                metadata={"method": "llm_judge", "error": str(e)},
+            )
+
+        return MetricResult(
+            score=score,
+            reason=f"LLM judge ({self._criteria.name}): {score:.4f}",
+            metadata={
+                "method": "llm_judge",
+                "criteria": self._criteria.name,
+                "provider": self._provider.name,
+            },
+        )
+
+    def _parse_score(self, response: str) -> float:
+        """Parse numeric score from LLM response text."""
+        import re
+
+        # Try to find a decimal number
+        match = re.search(r'(\d+\.?\d*)', response.strip())
+        if match:
+            score = float(match.group(1))
+            # Normalize to 0-1 range if needed
+            if score > 1.0:
+                # Could be percentage (85 -> 0.85) or scale (8.5 -> 0.85)
+                if score <= 10.0:
+                    score = score / 10.0
+                else:
+                    score = min(score / 100.0, 1.0)
+            return max(0.0, min(1.0, score))
+
+        # Fallback: check for keywords
+        response_lower = response.lower()
+        if any(word in response_lower for word in ["yes", "true", "fully", "completely", "excellent"]):
+            return 1.0
+        if any(word in response_lower for word in ["no", "false", "not at all", "poor"]):
+            return 0.0
+
+        return 0.5  # Default neutral score
+
+
+class AsyncLLMJudgeMetric(LLMJudgeMetric):
+    """Async version of LLMJudgeMetric for use in async pipelines."""
+
+    async def evaluate_async(self, **kwargs: Any) -> MetricResult:
+        """Evaluate asynchronously.
+
+        Args:
+            premise: The context or question.
+            hypothesis: The answer or text to evaluate.
+
+        Returns:
+            MetricResult with LLM-judged score.
+        """
+        premise = kwargs.get("premise", "")
+        hypothesis = kwargs.get("hypothesis", "")
+
+        if not premise or not hypothesis:
+            return MetricResult(
+                score=0.0,
+                reason="Missing premise or hypothesis",
+                metadata={"method": "llm_judge", "criteria": self._criteria.name},
+            )
+
+        prompt = self._criteria.scoring_prompt.format(
+            premise=premise, hypothesis=hypothesis
+        )
+
+        try:
+            response = await self._provider.generate(prompt)
+            score = self._parse_score(response)
+        except Exception as e:
+            logger.error("Async LLM judge failed: {}", e)
+            return MetricResult(
+                score=0.0,
+                reason=f"LLM judge failed: {e}",
+                metadata={"method": "llm_judge", "error": str(e)},
+            )
+
+        return MetricResult(
+            score=score,
+            reason=f"LLM judge ({self._criteria.name}): {score:.4f}",
+            metadata={
+                "method": "llm_judge",
+                "criteria": self._criteria.name,
+                "provider": self._provider.name,
+            },
+        )

--- a/openagent_eval/metrics/generation/relevancy.py
+++ b/openagent_eval/metrics/generation/relevancy.py
@@ -1,12 +1,15 @@
 """Answer Relevancy metric.
 
 Measures whether the generated answer addresses the original question.
-Uses Ragas answer_relevancy score when available, falls back to simple heuristics.
+Uses Ragas answer_relevancy score when available, falls back to NLI-based
+scoring, and finally to simple heuristics.
 """
 
 from __future__ import annotations
 
 from typing import Any
+
+from loguru import logger
 
 from openagent_eval.metrics.base import BaseMetric, MetricResult
 
@@ -14,9 +17,14 @@ from openagent_eval.metrics.base import BaseMetric, MetricResult
 class AnswerRelevancy(BaseMetric):
     """Measures relevancy of answer to the question.
 
-    Answer Relevancy = |question words in answer| / |total question words|
+    Answer Relevancy = |question concepts covered by answer| / |total question concepts|
 
     A score of 1.0 means the answer fully addresses the question.
+
+    Scoring priority:
+    1. Ragas (if available) — most accurate
+    2. NLI-based (if transformers available) — checks if answer entails question
+    3. Simple word overlap — fast fallback
     """
 
     name = "answer_relevancy"
@@ -28,6 +36,7 @@ class AnswerRelevancy(BaseMetric):
         Args:
             question: The original question.
             answer: The generated answer.
+            contexts: Optional context strings (unused, for API consistency).
 
         Returns:
             MetricResult with relevancy score.
@@ -54,6 +63,12 @@ class AnswerRelevancy(BaseMetric):
             return self._evaluate_with_ragas(question, answer)
         except ImportError:
             pass
+
+        # Try NLI-based scoring if available
+        try:
+            return self._evaluate_with_nli(question, answer)
+        except (ImportError, Exception) as e:
+            logger.debug("NLI scoring unavailable, using simple overlap: {}", e)
 
         # Fallback: simple word overlap
         return self._evaluate_simple(question, answer)
@@ -87,6 +102,35 @@ class AnswerRelevancy(BaseMetric):
             score=score,
             reason=f"Ragas answer relevancy: {score:.4f}",
             metadata={"method": "ragas"},
+        )
+
+    def _evaluate_with_nli(
+        self, question: str, answer: str
+    ) -> MetricResult:
+        """Evaluate using NLI: check if answer entails the question.
+
+        For relevancy, we check if the answer is relevant to the question
+        by evaluating whether the question's key information is addressed.
+        """
+        from openagent_eval.metrics.nli import NLIJudge
+
+        judge = NLIJudge()
+
+        # Check if answer is relevant to question
+        # Premise: answer, Hypothesis: question (does answer support the question?)
+        result = judge.evaluate(premise=answer, hypothesis=question)
+
+        # High entailment means answer is relevant to question
+        score = result.entailed_score
+
+        return MetricResult(
+            score=score,
+            reason=f"NLI relevancy: {result.label.value} (score: {score:.4f})",
+            metadata={
+                "method": "nli",
+                "label": result.label.value,
+                "model": judge._model_name,
+            },
         )
 
     def _evaluate_simple(self, question: str, answer: str) -> MetricResult:

--- a/openagent_eval/metrics/nli/__init__.py
+++ b/openagent_eval/metrics/nli/__init__.py
@@ -1,0 +1,44 @@
+"""NLI-based scoring module for OpenAgent Eval.
+
+Provides Natural Language Inference (NLI) based metrics for more accurate
+faithfulness and relevancy scoring. Uses DeBERTa NLI model to determine
+whether claims are entailed by context, replacing simple word-overlap.
+
+Components:
+- NLIJudge: Core NLI scoring using DeBERTa model
+- ClaimExtractor: Split answers into atomic claims
+- EvidenceFinder: Match claims to supporting context via NLI
+
+Example:
+    ```python
+    from openagent_eval.metrics.nli import NLIJudge, ClaimExtractor, EvidenceFinder
+
+    # Direct NLI scoring
+    judge = NLIJudge()
+    result = judge.evaluate(
+        premise="The sky is blue.",
+        hypothesis="The sky is blue and clear."
+    )
+
+    # Extract claims and find evidence
+    extractor = ClaimExtractor()
+    claims = extractor.extract("Python was created in 1991. It is open source.")
+
+    finder = EvidenceFinder(judge)
+    score, matches = finder.score_faithfulness(claims, contexts)
+    ```
+"""
+
+from openagent_eval.metrics.nli.claim_extractor import Claim, ClaimExtractor
+from openagent_eval.metrics.nli.evidence_finder import EvidenceFinder, EvidenceMatch
+from openagent_eval.metrics.nli.judge import NLIJudge, NLIResult, NLILabel
+
+__all__ = [
+    "Claim",
+    "ClaimExtractor",
+    "EvidenceFinder",
+    "EvidenceMatch",
+    "NLIJudge",
+    "NLIResult",
+    "NLILabel",
+]

--- a/openagent_eval/metrics/nli/claim_extractor.py
+++ b/openagent_eval/metrics/nli/claim_extractor.py
@@ -1,0 +1,150 @@
+"""Claim extractor for splitting answers into atomic claims.
+
+Extracts individual factual claims from a generated answer so each
+can be independently verified against context using NLI.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Claim:
+    """An atomic factual claim extracted from an answer.
+
+    Attributes:
+        text: The claim text.
+        index: Position of the claim in the original answer.
+    """
+
+    text: str
+    index: int
+
+
+class ClaimExtractor:
+    """Extracts atomic claims from generated answers.
+
+    Splits an answer into individual factual statements that can each
+    be independently verified against context using NLI scoring.
+
+    Example:
+        ```python
+        extractor = ClaimExtractor()
+        claims = extractor.extract(
+            "Python was created by Guido van Rossum. It was released in 1991."
+        )
+        # [Claim(text="Python was created by Guido van Rossum", index=0),
+        #  Claim(text="It was released in 1991", index=1)]
+        ```
+    """
+
+    # Sentence-ending patterns
+    _SENTENCE_SPLIT = re.compile(r'(?<=[.!?])\s+')
+
+    # Patterns that indicate a single claim
+    _SIMPLE_PATTERNS = re.compile(
+        r'^(?:'
+        r'(?:The|A|An)\s+\w+\s+(?:is|are|was|were)\s+'  # "The X is Y"
+        r'|(?:It|This|That)\s+(?:is|are|was|were)\s+'     # "It is Y"
+        r'|\w+\s+(?:has|have|had)\s+'                      # "X has Y"
+        r'|\w+\s+(?:can|could|will|would|should)\s+'      # "X can Y"
+        r')',
+        re.IGNORECASE,
+    )
+
+    def extract(self, answer: str) -> list[Claim]:
+        """Extract atomic claims from an answer.
+
+        Args:
+            answer: The generated answer text.
+
+        Returns:
+            List of Claim objects, one per extracted claim.
+        """
+        if not answer or not answer.strip():
+            return []
+
+        # Split into sentences
+        sentences = self._split_sentences(answer)
+
+        # Further split compound sentences
+        claims: list[Claim] = []
+        for sentence in sentences:
+            sub_claims = self._split_compound(sentence)
+            for sub_claim in sub_claims:
+                cleaned = self._clean_claim(sub_claim)
+                if cleaned:
+                    claims.append(Claim(text=cleaned, index=len(claims)))
+
+        return claims
+
+    def _split_sentences(self, text: str) -> list[str]:
+        """Split text into sentences."""
+        sentences = self._SENTENCE_SPLIT.split(text.strip())
+        return [s.strip() for s in sentences if s.strip()]
+
+    def _split_compound(self, sentence: str) -> list[str]:
+        """Split compound sentences into simpler claims.
+
+        Handles conjunctions like 'and', 'but', 'also'.
+        """
+        # Split on coordinating conjunctions preceded by comma
+        parts = re.split(r',\s*(?:and|but|also|moreover|furthermore|however)\s+', sentence, flags=re.IGNORECASE)
+
+        # If no split happened, try splitting on semicolons
+        if len(parts) == 1:
+            parts = re.split(r';\s*', sentence)
+
+        return parts if len(parts) > 1 else [sentence]
+
+    def _clean_claim(self, text: str) -> str:
+        """Clean and normalize a claim string."""
+        text = text.strip()
+        # Remove leading/trailing punctuation
+        text = text.strip('.,;:!?')
+        # Normalize whitespace
+        text = re.sub(r'\s+', ' ', text)
+        return text
+
+    def extract_with_context(
+        self, answer: str, contexts: list[str]
+    ) -> list[tuple[Claim, str]]:
+        """Extract claims and pair each with the most relevant context.
+
+        Uses simple keyword overlap to find the best matching context
+        for each claim. For NLI-based matching, use EvidenceFinder.
+
+        Args:
+            answer: The generated answer text.
+            contexts: List of context strings.
+
+        Returns:
+            List of (Claim, best_matching_context) tuples.
+        """
+        claims = self.extract(answer)
+        if not contexts:
+            return [(claim, "") for claim in claims]
+
+        paired: list[tuple[Claim, str]] = []
+        for claim in claims:
+            best_ctx = self._find_best_context(claim.text, contexts)
+            paired.append((claim, best_ctx))
+
+        return paired
+
+    def _find_best_context(self, claim: str, contexts: list[str]) -> str:
+        """Find the context with highest keyword overlap to the claim."""
+        claim_words = set(claim.lower().split())
+        best_score = -1
+        best_ctx = contexts[0] if contexts else ""
+
+        for ctx in contexts:
+            ctx_words = set(ctx.lower().split())
+            overlap = len(claim_words & ctx_words)
+            if overlap > best_score:
+                best_score = overlap
+                best_ctx = ctx
+
+        return best_ctx

--- a/openagent_eval/metrics/nli/evidence_finder.py
+++ b/openagent_eval/metrics/nli/evidence_finder.py
@@ -1,0 +1,128 @@
+"""Evidence finder for matching claims to supporting context.
+
+Uses NLI scoring to find the best supporting evidence for each claim,
+enabling more accurate faithfulness evaluation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from openagent_eval.metrics.nli.claim_extractor import Claim
+from openagent_eval.metrics.nli.judge import NLIJudge, NLIResult, get_default_judge
+
+
+@dataclass(frozen=True)
+class EvidenceMatch:
+    """A claim matched with its best supporting evidence.
+
+    Attributes:
+        claim: The extracted claim.
+        evidence: The best matching context snippet.
+        nli_result: NLI evaluation result for the pair.
+        all_scores: NLI scores for all contexts tried.
+    """
+
+    claim: Claim
+    evidence: str
+    nli_result: NLIResult
+    all_scores: tuple[NLIResult, ...]
+
+
+class EvidenceFinder:
+    """Find supporting evidence for claims using NLI scoring.
+
+    For each claim, evaluates it against all available contexts using
+    NLI and returns the best matching evidence.
+
+    Example:
+        ```python
+        finder = EvidenceFinder()
+        matches = finder.find_evidence(
+            claim=Claim(text="Python was created in 1991", index=0),
+            contexts=[
+                "Python is a programming language.",
+                "Python was created by Guido van Rossum in 1991.",
+            ]
+        )
+        print(matches.evidence)  # "Python was created by Guido van Rossum in 1991."
+        print(matches.nli_result.label)  # NLILabel.ENTAILMENT
+        ```
+    """
+
+    def __init__(self, judge: NLIJudge | None = None) -> None:
+        """Initialize the evidence finder.
+
+        Args:
+            judge: NLI judge instance. Uses default if None.
+        """
+        self._judge = judge or get_default_judge()
+
+    def find_evidence(
+        self, claim: Claim, contexts: list[str]
+    ) -> EvidenceMatch | None:
+        """Find the best supporting evidence for a claim.
+
+        Args:
+            claim: The claim to find evidence for.
+            contexts: List of context strings to search.
+
+        Returns:
+            EvidenceMatch with best evidence, or None if no contexts.
+        """
+        if not contexts:
+            return None
+
+        results: list[NLIResult] = []
+        for ctx in contexts:
+            result = self._judge.evaluate(premise=ctx, hypothesis=claim.text)
+            results.append(result)
+
+        # Find the context with highest entailment score
+        best_idx = max(range(len(results)), key=lambda i: results[i].entailed_score)
+
+        return EvidenceMatch(
+            claim=claim,
+            evidence=contexts[best_idx],
+            nli_result=results[best_idx],
+            all_scores=tuple(results),
+        )
+
+    def find_evidence_batch(
+        self, claims: list[Claim], contexts: list[str]
+    ) -> list[EvidenceMatch | None]:
+        """Find evidence for multiple claims.
+
+        Args:
+            claims: List of claims to find evidence for.
+            contexts: List of context strings to search.
+
+        Returns:
+            List of EvidenceMatch (or None for empty contexts).
+        """
+        return [self.find_evidence(claim, contexts) for claim in claims]
+
+    def score_faithfulness(
+        self, claims: list[Claim], contexts: list[str], threshold: float = 0.5
+    ) -> tuple[float, list[EvidenceMatch | None]]:
+        """Score faithfulness as fraction of claims with supporting evidence.
+
+        Args:
+            claims: List of extracted claims.
+            contexts: List of context strings.
+            threshold: Minimum entailment score to consider a claim supported.
+
+        Returns:
+            Tuple of (faithfulness_score, list_of_matches).
+        """
+        if not claims:
+            return 0.0, []
+
+        matches = self.find_evidence_batch(claims, contexts)
+        supported = sum(
+            1 for m in matches
+            if m is not None and m.nli_result.entailed_score >= threshold
+        )
+
+        score = supported / len(claims)
+        return score, matches

--- a/openagent_eval/metrics/nli/judge.py
+++ b/openagent_eval/metrics/nli/judge.py
@@ -1,0 +1,161 @@
+"""NLI Judge using DeBERTa Natural Language Inference model.
+
+Provides NLI-based scoring for faithfulness and relevancy metrics.
+Uses a pretrained DeBERTa model fine-tuned on NLI tasks to determine
+whether a hypothesis is entailed by a premise.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from functools import lru_cache
+from typing import Any
+
+from loguru import logger
+
+
+class NLILabel(str, Enum):
+    """NLI prediction labels."""
+
+    ENTAILMENT = "entailment"
+    CONTRADICTION = "contradiction"
+    NEUTRAL = "neutral"
+
+
+@dataclass(frozen=True)
+class NLIResult:
+    """Result of an NLI evaluation.
+
+    Attributes:
+        label: The NLI prediction (entailment, contradiction, neutral).
+        score: Confidence score for the prediction (0.0 to 1.0).
+        entailed_score: Score specifically for entailment label.
+    """
+
+    label: NLILabel
+    score: float
+    entailed_score: float
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.score <= 1.0:
+            raise ValueError(f"Score must be between 0.0 and 1.0, got {self.score}")
+        if not 0.0 <= self.entailed_score <= 1.0:
+            raise ValueError(
+                f"Entailed score must be between 0.0 and 1.0, got {self.entailed_score}"
+            )
+
+
+class NLIJudge:
+    """NLI-based judge using DeBERTa model for natural language inference.
+
+    Uses a pretrained NLI model to determine whether a hypothesis is
+    entailed by a premise. This provides more accurate scoring than
+    word-overlap methods.
+
+    Example:
+        ```python
+        judge = NLIJudge()
+        result = judge.evaluate(
+            premise="The sky is blue and clear today.",
+            hypothesis="The sky is blue."
+        )
+        print(result.label)  # NLILabel.ENTAILMENT
+        print(result.entailed_score)  # 0.98
+        ```
+    """
+
+    DEFAULT_MODEL = "microsoft/deberta-v3-base-mnli"
+
+    def __init__(self, model_name: str | None = None) -> None:
+        """Initialize the NLI judge.
+
+        Args:
+            model_name: HuggingFace model name. Defaults to DeBERTa MNLI.
+        """
+        self._model_name = model_name or self.DEFAULT_MODEL
+        self._pipeline: Any = None
+
+    @property
+    def pipeline(self) -> Any:
+        """Lazily load the NLI pipeline (heavy import)."""
+        if self._pipeline is None:
+            logger.debug("Loading NLI model: {}", self._model_name)
+            from transformers import pipeline as hf_pipeline
+
+            self._pipeline = hf_pipeline(
+                "text-classification",
+                model=self._model_name,
+                top_k=None,
+                device=-1,  # CPU; use 0 for GPU if available
+            )
+            logger.debug("NLI model loaded successfully")
+        return self._pipeline
+
+    def evaluate(self, premise: str, hypothesis: str) -> NLIResult:
+        """Evaluate NLI between premise and hypothesis.
+
+        Args:
+            premise: The context/premise text.
+            hypothesis: The claim/hypothesis to verify.
+
+        Returns:
+            NLIResult with label, score, and entailed_score.
+        """
+        if not premise.strip() or not hypothesis.strip():
+            return NLIResult(
+                label=NLILabel.NEUTRAL,
+                score=1.0,
+                entailed_score=0.0,
+            )
+
+        inputs = f"{premise} [SEP] {hypothesis}"
+        predictions = self.pipeline(inputs)
+
+        # predictions is a list of dicts: [{"label": "entailment", "score": 0.99}, ...]
+        score_map = {
+            pred["label"].lower(): pred["score"]
+            for pred in predictions[0]
+        }
+
+        entailed_score = score_map.get("entailment", 0.0)
+        contradiction_score = score_map.get("contradiction", 0.0)
+        neutral_score = score_map.get("neutral", 0.0)
+
+        # Determine winning label
+        scores = {
+            NLILabel.ENTAILMENT: entailed_score,
+            NLILabel.CONTRADICTION: contradiction_score,
+            NLILabel.NEUTRAL: neutral_score,
+        }
+        winning_label = max(scores, key=scores.get)  # type: ignore[arg-type]
+        winning_score = scores[winning_label]
+
+        return NLIResult(
+            label=winning_label,
+            score=winning_score,
+            entailed_score=entailed_score,
+        )
+
+    def batch_evaluate(
+        self, pairs: list[tuple[str, str]]
+    ) -> list[NLIResult]:
+        """Evaluate multiple premise-hypothesis pairs.
+
+        Args:
+            pairs: List of (premise, hypothesis) tuples.
+
+        Returns:
+            List of NLIResult, one per pair.
+        """
+        return [self.evaluate(premise, hyp) for premise, hyp in pairs]
+
+
+@lru_cache(maxsize=1)
+def get_default_judge() -> NLIJudge:
+    """Get a cached default NLI judge instance.
+
+    Returns:
+        Cached NLIJudge instance.
+    """
+    return NLIJudge()

--- a/tests/integration/test_nli_metrics.py
+++ b/tests/integration/test_nli_metrics.py
@@ -1,0 +1,255 @@
+"""Integration tests for NLI-based metrics.
+
+Tests the full pipeline: ClaimExtractor -> EvidenceFinder -> Faithfulness/Relevancy.
+Uses mocked NLI pipeline to avoid requiring actual model download.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openagent_eval.metrics.generation.faithfulness import Faithfulness
+from openagent_eval.metrics.generation.relevancy import AnswerRelevancy
+from openagent_eval.metrics.nli import (
+    Claim,
+    ClaimExtractor,
+    EvidenceFinder,
+    NLIJudge,
+    NLIResult,
+    NLILabel,
+)
+from openagent_eval.metrics.base import MetricResult
+
+
+# ============================================================
+# Mocked NLI Pipeline Fixtures
+# ============================================================
+
+
+def _make_nli_result(entailed: float, neutral: float = 0.0, contradiction: float = 0.0):
+    """Helper to create NLI pipeline output."""
+    return [[
+        {"label": "entailment", "score": entailed},
+        {"label": "neutral", "score": neutral},
+        {"label": "contradiction", "score": contradiction},
+    ]]
+
+
+# ============================================================
+# Faithfulness Integration Tests
+# ============================================================
+
+
+class TestFaithfulnessNLIIntegration:
+    """Integration tests for Faithfulness metric with NLI fallback."""
+
+    def test_faithfulness_empty_answer(self):
+        metric = Faithfulness()
+        result = metric.evaluate(answer="", contexts=["context"])
+        assert result.score == 0.0
+        assert "No answer" in result.reason
+
+    def test_faithfulness_empty_contexts(self):
+        metric = Faithfulness()
+        result = metric.evaluate(answer="answer", contexts=[])
+        assert result.score == 0.0
+        assert "No contexts" in result.reason
+
+    @patch("openagent_eval.metrics.generation.faithfulness.Faithfulness._evaluate_with_ragas")
+    def test_faithfulness_fallback_to_simple(self, mock_ragas):
+        """When Ragas and NLI unavailable, should use simple overlap."""
+        mock_ragas.side_effect = ImportError("No ragas")
+
+        metric = Faithfulness()
+        # Mock NLI to also fail
+        with patch(
+            "openagent_eval.metrics.generation.faithfulness.Faithfulness._evaluate_with_nli",
+            side_effect=ImportError("No nli"),
+        ):
+            result = metric.evaluate(
+                answer="The sky is blue and clear today",
+                contexts=["The sky is blue and the weather is clear"],
+            )
+            assert result.score > 0.0
+            assert result.metadata["method"] == "simple_overlap"
+
+    @patch("openagent_eval.metrics.generation.faithfulness.Faithfulness._evaluate_with_ragas")
+    def test_faithfulness_with_mocked_nli(self, mock_ragas):
+        """Test NLI fallback path when Ragas unavailable."""
+        mock_ragas.side_effect = ImportError("No ragas")
+
+        with patch(
+            "openagent_eval.metrics.nli.NLIJudge"
+        ) as MockJudge, patch(
+            "openagent_eval.metrics.nli.ClaimExtractor"
+        ) as MockExtractor, patch(
+            "openagent_eval.metrics.nli.EvidenceFinder"
+        ) as MockFinder:
+            # Setup mocks
+            mock_judge_instance = MagicMock()
+            mock_judge_instance._model_name = "test-model"
+            MockJudge.return_value = mock_judge_instance
+
+            mock_extractor_instance = MagicMock()
+            mock_extractor_instance.extract.return_value = [
+                Claim(text="The sky is blue", index=0),
+                Claim(text="It is clear", index=1),
+            ]
+            MockExtractor.return_value = mock_extractor_instance
+
+            mock_finder_instance = MagicMock()
+            mock_finder_instance.score_faithfulness.return_value = (
+                0.75,
+                [
+                    MagicMock(nli_result=MagicMock(entailed_score=0.9)),
+                    MagicMock(nli_result=MagicMock(entailed_score=0.6)),
+                ],
+            )
+            MockFinder.return_value = mock_finder_instance
+
+            metric = Faithfulness()
+            result = metric.evaluate(
+                answer="The sky is blue and clear.",
+                contexts=["The sky is blue and the weather is clear."],
+            )
+
+            assert result.score == 0.75
+            assert result.metadata["method"] == "nli"
+            assert result.metadata["claims_total"] == 2
+            assert result.metadata["claims_supported"] == 2
+
+
+# ============================================================
+# AnswerRelevancy Integration Tests
+# ============================================================
+
+
+class TestAnswerRelevancyNLIIntegration:
+    """Integration tests for AnswerRelevancy metric with NLI fallback."""
+
+    def test_relevancy_empty_question(self):
+        metric = AnswerRelevancy()
+        result = metric.evaluate(question="", answer="answer")
+        assert result.score == 0.0
+        assert "No question" in result.reason
+
+    def test_relevancy_empty_answer(self):
+        metric = AnswerRelevancy()
+        result = metric.evaluate(question="question", answer="")
+        assert result.score == 0.0
+        assert "No answer" in result.reason
+
+    @patch("openagent_eval.metrics.generation.relevancy.AnswerRelevancy._evaluate_with_ragas")
+    def test_relevancy_fallback_to_simple(self, mock_ragas):
+        """When Ragas and NLI unavailable, should use simple overlap."""
+        mock_ragas.side_effect = ImportError("No ragas")
+
+        metric = AnswerRelevancy()
+        with patch(
+            "openagent_eval.metrics.generation.relevancy.AnswerRelevancy._evaluate_with_nli",
+            side_effect=ImportError("No nli"),
+        ):
+            result = metric.evaluate(
+                question="What is Python?",
+                answer="Python is a programming language.",
+            )
+            assert result.score > 0.0
+            assert result.metadata["method"] == "word_overlap"
+
+    @patch("openagent_eval.metrics.generation.relevancy.AnswerRelevancy._evaluate_with_ragas")
+    def test_relevancy_with_mocked_nli(self, mock_ragas):
+        """Test NLI fallback path when Ragas unavailable."""
+        mock_ragas.side_effect = ImportError("No ragas")
+
+        with patch(
+            "openagent_eval.metrics.nli.NLIJudge"
+        ) as MockJudge:
+            mock_judge_instance = MagicMock()
+            mock_judge_instance._model_name = "test-model"
+            mock_judge_instance.evaluate.return_value = NLIResult(
+                label=NLILabel.ENTAILMENT,
+                score=0.9,
+                entailed_score=0.88,
+            )
+            MockJudge.return_value = mock_judge_instance
+
+            metric = AnswerRelevancy()
+            result = metric.evaluate(
+                question="What is Python?",
+                answer="Python is a programming language created by Guido van Rossum.",
+            )
+
+            assert result.score == 0.88
+            assert result.metadata["method"] == "nli"
+            assert result.metadata["label"] == "entailment"
+
+
+# ============================================================
+# Full Pipeline Integration Tests
+# ============================================================
+
+
+class TestNLIPipelineIntegration:
+    """End-to-end integration tests for the NLI scoring pipeline."""
+
+    def test_claim_extractor_to_evidence_finder(self):
+        """Test full pipeline: extract claims -> find evidence -> score."""
+        # Mock NLI judge
+        mock_judge = MagicMock(spec=NLIJudge)
+        mock_judge.evaluate.side_effect = [
+            # Claim 1 vs Context 1
+            NLIResult(label=NLILabel.ENTAILMENT, score=0.95, entailed_score=0.95),
+            # Claim 1 vs Context 2
+            NLIResult(label=NLILabel.NEUTRAL, score=0.7, entailed_score=0.2),
+            # Claim 2 vs Context 1
+            NLIResult(label=NLILabel.NEUTRAL, score=0.6, entailed_score=0.3),
+            # Claim 2 vs Context 2
+            NLIResult(label=NLILabel.ENTAILMENT, score=0.88, entailed_score=0.88),
+        ]
+
+        extractor = ClaimExtractor()
+        finder = EvidenceFinder(judge=mock_judge)
+
+        # Extract claims
+        claims = extractor.extract(
+            "Python is open source. It was created in 1991."
+        )
+        assert len(claims) >= 2
+
+        # Find evidence and score
+        contexts = [
+            "Python is an open source programming language.",
+            "Python was first released in 1991 by Guido van Rossum.",
+        ]
+
+        score, matches = finder.score_faithfulness(claims, contexts, threshold=0.5)
+
+        # At least some claims should be supported
+        assert score > 0.0
+        assert len(matches) >= 2
+
+        # Each match should have evidence
+        for match in matches:
+            if match is not None:
+                assert match.evidence
+                assert match.nli_result
+
+    def test_metric_result_format(self):
+        """Ensure all NLI-based metrics return proper MetricResult."""
+        metric = Faithfulness()
+        result = metric.evaluate(answer="test", contexts=["test context"])
+        assert isinstance(result, MetricResult)
+        assert 0.0 <= result.score <= 1.0
+        assert isinstance(result.reason, str)
+        assert isinstance(result.metadata, dict)
+
+    def test_relevancy_metric_result_format(self):
+        """Ensure relevancy metric returns proper MetricResult."""
+        metric = AnswerRelevancy()
+        result = metric.evaluate(question="test question", answer="test answer")
+        assert isinstance(result, MetricResult)
+        assert 0.0 <= result.score <= 1.0
+        assert isinstance(result.reason, str)
+        assert isinstance(result.metadata, dict)

--- a/tests/unit/test_metrics/test_nli.py
+++ b/tests/unit/test_metrics/test_nli.py
@@ -1,0 +1,390 @@
+"""Unit tests for NLI-based scoring module.
+
+Tests NLIJudge, ClaimExtractor, EvidenceFinder, and LLMJudgeMetric.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openagent_eval.metrics.nli import (
+    Claim,
+    ClaimExtractor,
+    EvidenceFinder,
+    EvidenceMatch,
+    NLIJudge,
+    NLIResult,
+    NLILabel,
+)
+from openagent_eval.metrics.generation.llm_judge import (
+    LLMJudgeMetric,
+    AsyncLLMJudgeMetric,
+    JudgeCriteria,
+    FAITHFULNESS_CRITERIA,
+    RELEVANCY_CRITERIA,
+    COMPREHENSIVENESS_CRITERIA,
+)
+from openagent_eval.metrics.base import MetricResult
+
+
+# ============================================================
+# NLIResult Tests
+# ============================================================
+
+
+class TestNLIResult:
+    """Tests for NLIResult dataclass."""
+
+    def test_valid_result(self):
+        result = NLIResult(
+            label=NLILabel.ENTAILMENT,
+            score=0.95,
+            entailed_score=0.95,
+        )
+        assert result.label == NLILabel.ENTAILMENT
+        assert result.score == 0.95
+        assert result.entailed_score == 0.95
+
+    def test_invalid_score_too_high(self):
+        with pytest.raises(ValueError, match="Score must be between"):
+            NLIResult(
+                label=NLILabel.ENTAILMENT,
+                score=1.5,
+                entailed_score=0.9,
+            )
+
+    def test_invalid_score_too_low(self):
+        with pytest.raises(ValueError, match="Score must be between"):
+            NLIResult(
+                label=NLILabel.ENTAILMENT,
+                score=-0.1,
+                entailed_score=0.9,
+            )
+
+    def test_invalid_entailed_score(self):
+        with pytest.raises(ValueError, match="Entailed score must be between"):
+            NLIResult(
+                label=NLILabel.ENTAILMENT,
+                score=0.9,
+                entailed_score=1.5,
+            )
+
+
+# ============================================================
+# Claim Tests
+# ============================================================
+
+
+class TestClaim:
+    """Tests for Claim dataclass."""
+
+    def test_valid_claim(self):
+        claim = Claim(text="Python is open source", index=0)
+        assert claim.text == "Python is open source"
+        assert claim.index == 0
+
+    def test_claim_immutable(self):
+        claim = Claim(text="Test", index=0)
+        with pytest.raises(AttributeError):
+            claim.text = "Changed"  # type: ignore[misc]
+
+
+# ============================================================
+# ClaimExtractor Tests
+# ============================================================
+
+
+class TestClaimExtractor:
+    """Tests for ClaimExtractor."""
+
+    def setup_method(self):
+        self.extractor = ClaimExtractor()
+
+    def test_extract_empty_answer(self):
+        claims = self.extractor.extract("")
+        assert claims == []
+
+    def test_extract_whitespace_only(self):
+        claims = self.extractor.extract("   ")
+        assert claims == []
+
+    def test_extract_single_sentence(self):
+        claims = self.extractor.extract("Python was created in 1991.")
+        assert len(claims) >= 1
+        assert "1991" in claims[0].text
+
+    def test_extract_multiple_sentences(self):
+        text = "Python was created in 1991. It is open source. It supports multiple paradigms."
+        claims = self.extractor.extract(text)
+        assert len(claims) >= 2
+
+    def test_extract_compound_sentence(self):
+        text = "Python is popular, and it is easy to learn."
+        claims = self.extractor.extract(text)
+        # Should split on ", and"
+        assert len(claims) >= 1
+
+    def test_extract_claims_have_indices(self):
+        text = "First claim. Second claim. Third claim."
+        claims = self.extractor.extract(text)
+        for i, claim in enumerate(claims):
+            assert claim.index == i
+
+    def test_extract_with_context(self):
+        answer = "Python is open source."
+        contexts = ["Python is a programming language.", "Java is compiled."]
+        paired = self.extractor.extract_with_context(answer, contexts)
+        assert len(paired) >= 1
+        assert paired[0][0].text  # Claim text not empty
+        assert paired[0][1]  # Context not empty
+
+
+# ============================================================
+# EvidenceFinder Tests (with mocked NLI)
+# ============================================================
+
+
+class TestEvidenceFinder:
+    """Tests for EvidenceFinder with mocked NLI judge."""
+
+    def setup_method(self):
+        self.mock_judge = MagicMock(spec=NLIJudge)
+        self.finder = EvidenceFinder(judge=self.mock_judge)
+
+    def test_find_evidence_empty_contexts(self):
+        claim = Claim(text="Test claim", index=0)
+        result = self.finder.find_evidence(claim, [])
+        assert result is None
+
+    def test_find_evidence_best_match(self):
+        claim = Claim(text="Python is open source", index=0)
+        contexts = [
+            "Python is a compiled language.",
+            "Python is open source and free.",
+        ]
+
+        # Mock NLI results: second context entails better
+        self.mock_judge.evaluate.side_effect = [
+            NLIResult(label=NLILabel.NEUTRAL, score=0.6, entailed_score=0.3),
+            NLIResult(label=NLILabel.ENTAILMENT, score=0.9, entailed_score=0.9),
+        ]
+
+        result = self.finder.find_evidence(claim, contexts)
+        assert result is not None
+        assert result.evidence == contexts[1]
+        assert result.nli_result.entailed_score == 0.9
+
+    def test_score_faithfulness_all_supported(self):
+        claims = [
+            Claim(text="Claim 1", index=0),
+            Claim(text="Claim 2", index=1),
+        ]
+        contexts = ["Context 1", "Context 2"]
+
+        self.mock_judge.evaluate.return_value = NLIResult(
+            label=NLILabel.ENTAILMENT, score=0.95, entailed_score=0.95
+        )
+
+        score, matches = self.finder.score_faithfulness(claims, contexts)
+        assert score == 1.0
+        assert len(matches) == 2
+
+    def test_score_faithfulness_none_supported(self):
+        claims = [
+            Claim(text="Claim 1", index=0),
+            Claim(text="Claim 2", index=1),
+        ]
+        contexts = ["Context 1"]
+
+        self.mock_judge.evaluate.return_value = NLIResult(
+            label=NLILabel.CONTRADICTION, score=0.9, entailed_score=0.05
+        )
+
+        score, matches = self.finder.score_faithfulness(claims, contexts, threshold=0.5)
+        assert score == 0.0
+
+    def test_score_faithfulness_empty_claims(self):
+        score, matches = self.finder.score_faithfulness([], ["context"])
+        assert score == 0.0
+        assert matches == []
+
+
+# ============================================================
+# NLIJudge Tests (with mocked pipeline)
+# ============================================================
+
+
+class TestNLIJudge:
+    """Tests for NLIJudge with mocked pipeline."""
+
+    def setup_method(self):
+        self.judge = NLIJudge(model_name="test-model")
+
+    def test_empty_premise(self):
+        result = self.judge.evaluate(premise="", hypothesis="test")
+        assert result.label == NLILabel.NEUTRAL
+        assert result.entailed_score == 0.0
+
+    def test_empty_hypothesis(self):
+        result = self.judge.evaluate(premise="test", hypothesis="")
+        assert result.label == NLILabel.NEUTRAL
+        assert result.entailed_score == 0.0
+
+    def test_evaluate_entailment(self):
+        mock_pipe = MagicMock()
+        mock_pipe.return_value = [[
+            {"label": "entailment", "score": 0.95},
+            {"label": "neutral", "score": 0.03},
+            {"label": "contradiction", "score": 0.02},
+        ]]
+
+        judge = NLIJudge()
+        judge._pipeline = mock_pipe
+
+        result = judge.evaluate(
+            premise="The sky is blue.",
+            hypothesis="The sky has a color."
+        )
+        assert result.label == NLILabel.ENTAILMENT
+        assert result.entailed_score == 0.95
+
+    def test_evaluate_contradiction(self):
+        mock_pipe = MagicMock()
+        mock_pipe.return_value = [[
+            {"label": "entailment", "score": 0.05},
+            {"label": "neutral", "score": 0.1},
+            {"label": "contradiction", "score": 0.85},
+        ]]
+
+        judge = NLIJudge()
+        judge._pipeline = mock_pipe
+
+        result = judge.evaluate(
+            premise="The sky is blue.",
+            hypothesis="The sky is red."
+        )
+        assert result.label == NLILabel.CONTRADICTION
+        assert result.score == 0.85
+
+    def test_batch_evaluate(self):
+        with patch.object(NLIJudge, 'evaluate') as mock_eval:
+            mock_eval.return_value = NLIResult(
+                label=NLILabel.ENTAILMENT, score=0.9, entailed_score=0.9
+            )
+            judge = NLIJudge()
+            results = judge.batch_evaluate([
+                ("premise1", "hyp1"),
+                ("premise2", "hyp2"),
+            ])
+            assert len(results) == 2
+            assert all(r.label == NLILabel.ENTAILMENT for r in results)
+
+
+# ============================================================
+# LLMJudgeMetric Tests (with mocked provider)
+# ============================================================
+
+
+class TestLLMJudgeMetric:
+    """Tests for LLMJudgeMetric with mocked LLM provider."""
+
+    def setup_method(self):
+        self.mock_provider = MagicMock()
+        self.mock_provider.name = "test_provider"
+        self.mock_provider.generate = MagicMock(return_value="0.85")
+
+    def test_judge_criteria_defaults(self):
+        criteria = FAITHFULNESS_CRITERIA
+        assert criteria.name == "faithfulness"
+        assert criteria.passing_threshold == 0.7
+
+    def test_llm_judge_metric_name(self):
+        metric = LLMJudgeMetric(
+            provider=self.mock_provider,
+            criteria=RELEVANCY_CRITERIA,
+        )
+        assert metric.name == "llm_judge_relevancy"
+
+    def test_llm_judge_missing_inputs(self):
+        metric = LLMJudgeMetric(provider=self.mock_provider)
+        result = metric.evaluate(premise="", hypothesis="test")
+        assert result.score == 0.0
+        assert "Missing" in result.reason
+
+    def test_llm_judge_parse_score_decimal(self):
+        metric = LLMJudgeMetric(provider=self.mock_provider)
+        score = metric._parse_score("The score is 0.85")
+        assert score == 0.85
+
+    def test_llm_judge_parse_score_percentage(self):
+        metric = LLMJudgeMetric(provider=self.mock_provider)
+        score = metric._parse_score("85%")
+        assert score == 0.85  # 85 / 100
+
+    def test_llm_judge_parse_score_keyword_yes(self):
+        metric = LLMJudgeMetric(provider=self.mock_provider)
+        score = metric._parse_score("Yes, the answer is excellent")
+        assert score == 1.0
+
+    def test_llm_judge_parse_score_keyword_no(self):
+        metric = LLMJudgeMetric(provider=self.mock_provider)
+        score = metric._parse_score("No, not at all")
+        assert score == 0.0
+
+    def test_llm_judge_parse_score_neutral(self):
+        metric = LLMJudgeMetric(provider=self.mock_provider)
+        score = metric._parse_score("some random text")
+        assert score == 0.5
+
+    def test_llm_judge_evaluate_success(self):
+        self.mock_provider.generate.return_value = "0.92"
+        metric = LLMJudgeMetric(provider=self.mock_provider)
+        result = metric.evaluate(premise="context", hypothesis="answer")
+        assert result.score == 0.92
+        assert result.metadata["method"] == "llm_judge"
+
+    def test_llm_judge_evaluate_failure(self):
+        self.mock_provider.generate.side_effect = Exception("API error")
+        metric = LLMJudgeMetric(provider=self.mock_provider)
+        result = metric.evaluate(premise="context", hypothesis="answer")
+        assert result.score == 0.0
+        assert "failed" in result.reason.lower()
+
+
+# ============================================================
+# MetricResult Integration Tests
+# ============================================================
+
+
+class TestMetricResultNLI:
+    """Test that NLI-based metrics return proper MetricResult."""
+
+    def test_nli_result_is_frozen(self):
+        result = NLIResult(
+            label=NLILabel.ENTAILMENT,
+            score=0.9,
+            entailed_score=0.9,
+        )
+        with pytest.raises(AttributeError):
+            result.score = 0.5  # type: ignore[misc]
+
+    def test_claim_is_frozen(self):
+        claim = Claim(text="test", index=0)
+        with pytest.raises(AttributeError):
+            claim.text = "changed"  # type: ignore[misc]
+
+    def test_evidence_match_is_frozen(self):
+        match = EvidenceMatch(
+            claim=Claim(text="test", index=0),
+            evidence="context",
+            nli_result=NLIResult(
+                label=NLILabel.ENTAILMENT,
+                score=0.9,
+                entailed_score=0.9,
+            ),
+            all_scores=(),
+        )
+        with pytest.raises(AttributeError):
+            match.evidence = "changed"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Implements Phase 10: LLM-as-Judge Metrics — NLI-based scoring to replace word-overlap fallbacks for faithfulness and relevancy metrics.

## Changes

### New NLI Module (openagent_eval/metrics/nli/)
- **NLIJudge** — DeBERTa-based Natural Language Inference for claim verification
- **ClaimExtractor** — Splits answers into atomic factual claims
- **EvidenceFinder** — Matches claims to supporting context via NLI scoring

### Upgraded Metrics
- **Faithfulness** — Now uses NLI fallback (Ragas → NLI → word overlap)
- **AnswerRelevancy** — Now uses NLI fallback (Ragas → NLI → word overlap)

### Generic LLM Judge
- **LLMJudgeMetric** — Flexible metric for custom quality criteria with predefined templates

## Testing
- 36 new unit tests for NLI scoring (all passing)
- 11 new integration tests for NLI-based metrics (all passing)
- All 134 existing tests continue to pass

## Architecture
The NLI module follows the project's adapter pattern:
`
metrics/nli/
├── __init__.py          # Public API
├── judge.py             # NLIJudge using DeBERTa MNLI
├── claim_extractor.py   # Split answers into claims
└── evidence_finder.py   # Match claims to evidence
`

## Dependencies
The 
li optional dependency group was already defined in pyproject.toml:
- 	ransformers>=4.30.0
- 	orch>=2.0.0

## Related
- Closes #Phase 10 from TASKS.md
- Enables NLI-based scoring for production-grade RAG evaluation