### PR TITLE
feat: auto-assign issues workflow

### DIFF
--- a/.github/workflows/auto-assign-issue.yml
+++ b/.github/workflows/auto-assign-issue.yml
@@ -1,0 +1,111 @@
+name: Auto-Assign Issues
+
+on:
+  issues:
+    types: [commented]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-assign issue to commenter
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const comment = context.payload.comment;
+            const commenter = comment.user.login;
+            const issueAuthor = issue.user.login;
+
+            // Trigger phrases (case-insensitive)
+            const triggerPhrases = [
+              'i want to work on this',
+              "i'd like to work on this",
+              'can i work on this',
+              'assign me',
+              "i'll take this",
+              'let me handle this',
+              'i can work on this'
+            ];
+
+            const commentBody = comment.body.toLowerCase().trim();
+
+            // Check if comment contains a trigger phrase
+            const hasTrigger = triggerPhrases.some(phrase =>
+              commentBody.includes(phrase)
+            );
+
+            if (!hasTrigger) {
+              console.log('No trigger phrase found. Skipping.');
+              return;
+            }
+
+            console.log(`Trigger phrase found from @${commenter}`);
+
+            // Check if the commenter is a bot
+            if (comment.user.type === 'Bot') {
+              console.log('Commenter is a bot. Skipping.');
+              return;
+            }
+
+            // Check if issue is already assigned
+            if (issue.assignees && issue.assignees.length > 0) {
+              const assignedNames = issue.assignees.map(a => a.login).join(', ');
+              console.log(`Issue already assigned to: ${assignedNames}. Skipping.`);
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `@${commenter} This issue is already assigned to @${assignedNames}. Please pick another issue or wait for the assignment to be released.`
+              });
+              return;
+            }
+
+            // Assign the issue to the commenter
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              assignees: [commenter]
+            });
+
+            console.log(`Assigned issue #${issue.number} to @${commenter}`);
+
+            // Add 'assigned' label
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['assigned']
+              });
+              console.log('Added "assigned" label.');
+            } catch (error) {
+              console.log(`Could not add label: ${error.message}`);
+            }
+
+            // Post confirmation comment
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: [
+                `@${commenter} has been assigned to this issue! 🎉`,
+                '',
+                '**Next steps:**',
+                '1. Fork the repository',
+                '2. Create a feature branch (`git checkout -b feature/your-feature`)',
+                '3. Make your changes and commit (`git commit -m "feat: add your feature"`)',
+                '4. Push to your fork and open a Pull Request',
+                '',
+                'Please read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md) before starting.',
+                '',
+                'Good luck! Happy coding! 🚀'
+              ].join('\n')
+            });


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically assigns issues when a contributor comments with a trigger phrase.

## How It Works

1. A contributor comments on an open issue with a trigger phrase
2. The workflow checks if the phrase matches and the issue is unassigned
3. The issue is assigned to the commenter with an `assigned` label
4. A confirmation comment is posted with next steps

## Trigger Phrases (case-insensitive)

- `I want to work on this`
- `I'd like to work on this`
- `Can I work on this`
- `assign me`
- `I'll take this`
- `Let me handle this`
- `I can work on this`

## Features

- Case-insensitive matching
- Skips bot comments
- Prevents re-assignment if issue already has assignees
- Adds `assigned` label for tracking
- Posts confirmation with contributing guidelines link
- Self-assign allowed (issue creator can assign themselves)

## Workflow Permissions

- `issues: write` — to assign and comment
- `contents: read` — default

## Example Usage

```
Comment: "I'd like to work on this"
Result: Issue assigned to commenter, label added, confirmation posted
```
