### PR TITLE
fix(cli): interpolate timeout in dry-run warning

### DIFF
--- a/openagent_eval/cli/commands/run.py
+++ b/openagent_eval/cli/commands/run.py
@@ -240,7 +240,9 @@ def _run_dry_run(config: object, config_path: Path) -> None:
     # Show warnings
     console.print("\n[bold]Warnings:[/bold]")
     if config.timeout < 60:
-        console.print("  [yellow]Timeout is low ({config.timeout}s) - evaluations may time out[/yellow]")
+        console.print(
+            f"  [yellow]Timeout is low ({config.timeout}s) - evaluations may time out[/yellow]"
+        )
     if len(config.metrics.generation) > 5:
         console.print(f"  [yellow]Running {len(config.metrics.generation)} generation metrics may be slow[/yellow]")
 

--- a/tests/unit/test_cli/test_cli_improvements.py
+++ b/tests/unit/test_cli/test_cli_improvements.py
@@ -3,11 +3,20 @@
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
 
 from typer.testing import CliRunner
 
+from openagent_eval.cli.context import (
+    CLIContext,
+    get_context,
+    reset_context,
+    set_context,
+)
 from openagent_eval.cli.main import app
-from openagent_eval.cli.context import CLIContext, get_context, set_context, reset_context
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 runner = CliRunner()
 
@@ -167,6 +176,22 @@ class TestRunCommandImprovements:
         """Test dry-run with missing config."""
         result = runner.invoke(app, ["run", "--dry-run", "nonexistent.yaml"])
         assert result.exit_code == 2
+
+    def test_run_dry_run_interpolates_timeout_warning(
+        self, sample_config_path: Path
+    ) -> None:
+        """Dry-run warnings should display the configured timeout value."""
+        sample_config_path.write_text(
+            f"{sample_config_path.read_text()}\ntimeout: 30\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(app, ["run", "--dry-run", str(sample_config_path)])
+
+        assert result.exit_code == 0
+        output = strip_ansi(result.output)
+        assert "Timeout is low (30.0s)" in output
+        assert "{config.timeout}" not in output
 
 
 class TestDoctorCommandImprovements:


### PR DESCRIPTION
## Summary

The dry-run warning now displays the configured timeout instead of the literal `{config.timeout}` placeholder.

Fixes #97

## Changes

- Add the missing f-string prefix in `openagent_eval/cli/commands/run.py`.
- Add a regression test covering a 30-second timeout.

## Testing

```bash
.venv/bin/python -m pytest tests/unit/test_cli/test_cli_improvements.py -q
```

Result: 34 passed.

The repository-wide unit run reached 739 passed but still has unrelated failures requiring optional `openai`, `tiktoken`, and `pypdf` dependencies, plus an existing semantic-similarity threshold failure. Scoped Ruff reports only the pre-existing `test_version_V_flag` naming issue in the touched test file.

## Checklist

- [x] Regression test added
- [x] Targeted tests pass
- [x] No external services or API keys required