### PR TITLE
fix(metrics): preserve zero timeout details

### DIFF
--- a/openagent_eval/exceptions/metric.py
+++ b/openagent_eval/exceptions/metric.py
@@ -116,7 +116,7 @@ class MetricTimeoutError(MetricError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if timeout_seconds:
+        if timeout_seconds is not None:
             error_details["timeout_seconds"] = timeout_seconds
 
         super().__init__(message=message, metric_name=metric_name, details=error_details)

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-
 from openagent_eval.exceptions import (
     CLIError,
     CommandError,
@@ -123,6 +122,12 @@ class TestMetricError:
         """Test metric timeout error."""
         error = MetricTimeoutError("Timed out", timeout_seconds=30.0)
         assert error.timeout_seconds == 30.0
+
+    def test_timeout_error_preserves_zero_timeout(self) -> None:
+        """Test that a zero timeout is retained in the error details."""
+        error = MetricTimeoutError("Timed out immediately", timeout_seconds=0.0)
+        assert error.timeout_seconds == 0.0
+        assert error.details["timeout_seconds"] == 0.0
 
 
 class TestProviderError:


### PR DESCRIPTION
## Description

Fix `MetricTimeoutError` so an explicit `timeout_seconds=0.0` is retained in the exception details instead of being dropped by a truthiness check.

## Type of Change

- [x] Bug fix
- [x] Test update

## Related Issues

Closes #124

## Changes

- Use `timeout_seconds is not None` when adding timeout metadata.
- Add a regression test that checks both the public attribute and serialized `details` value for `0.0`.

## Verification

- Focused unit tests: `.venv/bin/python -m pytest tests/unit/test_exceptions.py` — 25 passed.
- Targeted lint: `.venv/bin/ruff check openagent_eval/exceptions/metric.py tests/unit/test_exceptions.py` — passed.
- `git diff --check` — passed.
- Full local suite: 791 passed, 9 failed, 11 errors, 8 skipped. The failures are pre-existing/environmental: missing optional `pypdf`, OpenAI provider packages, and an existing semantic-similarity threshold mismatch.
- Full-repository Ruff and mypy remain non-zero on pre-existing baseline issues (219 Ruff findings and 168 mypy errors); CI marks these advisory checks as allowed to fail.

## Checklist

- [x] Added a regression test proving the fix
- [x] Commit follows the project format
- [x] Commit author and committer are `hkJerryLeung <hkjerryleung@gmail.com>`
