### PR TITLE
fix: export all cli commands

### DIFF
--- a/openagent_eval/cli/commands/__init__.py
+++ b/openagent_eval/cli/commands/__init__.py
@@ -1,17 +1,29 @@
 """CLI commands for OpenAgent Eval."""
 
+from openagent_eval.cli.commands.audit import audit_command
 from openagent_eval.cli.commands.compare import compare_command
+from openagent_eval.cli.commands.delete import delete_command
+from openagent_eval.cli.commands.diagnose import diagnose_command
 from openagent_eval.cli.commands.doctor import doctor_command
 from openagent_eval.cli.commands.init import init_command
 from openagent_eval.cli.commands.list_evaluations import list_command
 from openagent_eval.cli.commands.report import report_command
 from openagent_eval.cli.commands.run import run_command
+from openagent_eval.cli.commands.synth import synth_command
+from openagent_eval.cli.commands.test import test_command
+from openagent_eval.cli.commands.validate import validate_command
 
 __all__ = [
+    "audit_command",
     "init_command",
     "run_command",
     "report_command",
     "compare_command",
     "list_command",
     "doctor_command",
+    "validate_command",
+    "delete_command",
+    "diagnose_command",
+    "synth_command",
+    "test_command",
 ]

--- a/tests/unit/test_cli/test_main.py
+++ b/tests/unit/test_cli/test_main.py
@@ -61,6 +61,29 @@ def test_cli_doctor_help():
     assert result.exit_code == 0
 
 
+def test_all_cli_commands_are_exported():
+    """Test that every command is available from the package namespace."""
+    from openagent_eval.cli import commands
+
+    expected = {
+        "audit_command",
+        "compare_command",
+        "delete_command",
+        "diagnose_command",
+        "doctor_command",
+        "init_command",
+        "list_command",
+        "report_command",
+        "run_command",
+        "synth_command",
+        "test_command",
+        "validate_command",
+    }
+
+    assert set(commands.__all__) == expected
+    assert all(hasattr(commands, name) for name in expected)
+
+
 def test_cli_invalid_command():
     """Test that CLI handles invalid commands gracefully."""
     result = runner.invoke(app, ["invalid-command"])


### PR DESCRIPTION
## What

Fixes #101 by exporting all CLI command callables from `openagent_eval.cli.commands`.

## Why

`cli/main.py` registered the commands directly, but the package namespace omitted `audit`, `delete`, `diagnose`, `synth`, `test`, and `validate`. Consumers importing from `openagent_eval.cli.commands` could not access those commands.

## Changes

- Add the six missing command imports and `__all__` entries.
- Add a regression test that verifies every command is present in the package namespace.

## Testing

- `uv run --frozen --python 3.12 pytest tests/unit/test_cli/test_main.py -q` — 11 passed
- `uv run --frozen --python 3.12 ruff check openagent_eval/cli/commands/__init__.py tests/unit/test_cli/test_main.py`
- `uv run --frozen --python 3.12 ruff format --check openagent_eval/cli/commands/__init__.py tests/unit/test_cli/test_main.py`
- `git diff --check`

The full suite was also attempted; 790 tests passed and 8 were skipped, while unrelated tests requiring optional `pypdf`/OpenAI provider packages and an existing semantic-similarity threshold failed in this minimal environment.