### PR TITLE
fix(cli): use mock provider for synth

### DIFF
--- a/openagent_eval/cli/commands/synth.py
+++ b/openagent_eval/cli/commands/synth.py
@@ -25,10 +25,13 @@ from rich.panel import Panel
 from rich.table import Table
 
 from openagent_eval.cli.context import get_context
+from openagent_eval.config.models import LLMConfig
 from openagent_eval.exceptions.synthesis import SynthesisError
+from openagent_eval.providers.factory import get_llm_provider
 from openagent_eval.synthesis import SyntheticDataGenerator, TestCaseType
 
 if TYPE_CHECKING:
+    from openagent_eval.providers.base.llm import LLMProvider
     from openagent_eval.synthesis.models import SyntheticDataset
 
 console = Console()
@@ -252,7 +255,7 @@ async def _run_generation(
         )
 
 
-def _create_provider(provider_name: str, model: str) -> object:
+def _create_provider(provider_name: str, model: str) -> LLMProvider:
     """Create an LLM provider instance.
 
     Args:
@@ -263,31 +266,17 @@ def _create_provider(provider_name: str, model: str) -> object:
         LLMProvider instance.
 
     Raises:
+        ProviderNotFoundError: If the provider name is unknown.
         ImportError: If the provider SDK is not installed.
     """
-    if provider_name == "openai":
-        from openagent_eval.providers.llm.openai import OpenAIProvider
-
-        return OpenAIProvider(model=model)
-    elif provider_name == "gemini":
-        from openagent_eval.providers.llm.gemini import GeminiProvider
-
-        return GeminiProvider(model=model)
-    elif provider_name == "anthropic":
-        from openagent_eval.providers.llm.anthropic import AnthropicProvider
-
-        return AnthropicProvider(model=model)
-    elif provider_name == "groq":
-        from openagent_eval.providers.llm.groq import GroqProvider
-
-        return GroqProvider(model=model)
-    elif provider_name == "mock":
-        from openagent_eval.providers.llm.openai import OpenAIProvider
-
-        # For testing, use OpenAI provider as fallback
-        return OpenAIProvider(model=model)
-    else:
-        raise ValueError(f"Unsupported LLM provider: {provider_name}")
+    config = LLMConfig(
+        provider=provider_name,
+        model=model,
+        api_key=None,
+        temperature=0.0,
+        max_tokens=None,
+    )
+    return get_llm_provider(config)
 
 
 def _save_output(

--- a/tests/unit/test_cli/test_synth.py
+++ b/tests/unit/test_cli/test_synth.py
@@ -1,0 +1,19 @@
+"""Tests for the synthetic data CLI command."""
+
+from __future__ import annotations
+
+import asyncio
+
+from openagent_eval.cli.commands.synth import _create_provider
+from openagent_eval.providers.llm.mock import MockLLMProvider
+
+
+def test_create_provider_uses_offline_mock_provider() -> None:
+    """The mock CLI option must not fall back to a network provider."""
+    provider = _create_provider("mock", "synthetic-test-model")
+
+    assert isinstance(provider, MockLLMProvider)
+
+    response = asyncio.run(provider.generate_with_usage("test prompt"))
+    assert response.provider == "mock"
+    assert response.model == "synthetic-test-model"


### PR DESCRIPTION
## Description

Routes the synth command's LLM construction through the central provider factory instead of maintaining a duplicated provider switch. This makes `--llm-provider mock` instantiate `MockLLMProvider` and keeps all CLI provider mappings aligned with the registry.

Adds a regression test that verifies the mock provider remains offline and reports the requested model.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

## Related Issues

Closes #100

## How Has This Been Tested?

- [x] Targeted unit tests pass (`4 passed`)
- [x] Changed files pass Ruff
- [x] `synth.py` passes mypy
- [x] Manual self-review performed

Commands:

```bash
python -m pytest tests/unit/test_cli/test_synth.py tests/unit/test_providers/test_factory.py -q -p no:cacheprovider
ruff check openagent_eval/cli/commands/synth.py tests/unit/test_cli/test_synth.py
mypy openagent_eval/cli/commands/synth.py
```

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective

## Additional Notes

The repository-wide Ruff and mypy commands currently report pre-existing findings outside this change. A broader local pytest run reached 43 passing tests, with 6 setup errors caused by Windows sandbox denial of pytest temporary directories.