### PR TITLE
fix(synthesis): _read_corpus no longer silently swallows file reading errors (#93)

### DIFF
--- a/openagent_eval/synthesis/generator.py
+++ b/openagent_eval/synthesis/generator.py
@@ -75,7 +75,8 @@ def _read_corpus(corpus_path: str | Path) -> list[tuple[str, str]]:
         List of (filename, content) tuples.
 
     Raises:
-        SynthesisExecutionError: If the path doesn't exist or can't be read.
+        SynthesisExecutionError: If the path doesn't exist, can't be read,
+            or any files fail to read.
     """
     path = Path(corpus_path)
     if not path.exists():
@@ -85,10 +86,19 @@ def _read_corpus(corpus_path: str | Path) -> list[tuple[str, str]]:
         )
 
     if path.is_file():
-        content = path.read_text(encoding="utf-8")
-        return [(path.name, content)]
+        try:
+            content = path.read_text(encoding="utf-8")
+            return [(path.name, content)]
+        except Exception as e:
+            raise SynthesisExecutionError(
+                message=f"Failed to read corpus file: {path}",
+                original_error=e,
+                details={"path": str(path)},
+            )
 
     documents: list[tuple[str, str]] = []
+    failed_files: list[dict[str, str]] = []
+
     for file_path in sorted(path.rglob("*")):
         if file_path.is_file() and file_path.suffix.lower() in {
             ".txt",
@@ -102,7 +112,16 @@ def _read_corpus(corpus_path: str | Path) -> list[tuple[str, str]]:
                 content = file_path.read_text(encoding="utf-8")
                 documents.append((str(file_path.relative_to(path)), content))
             except Exception as e:
+                failed_files.append(
+                    {"file": str(file_path.relative_to(path)), "error": str(e)}
+                )
                 logger.warning("Failed to read %s: %s", file_path, e)
+
+    if failed_files:
+        raise SynthesisExecutionError(
+            message=f"Failed to read {len(failed_files)} file(s) from corpus",
+            details={"failed_files": failed_files, "corpus_path": str(path)},
+        )
 
     return documents
 

--- a/tests/unit/test_synthesis/test_generator.py
+++ b/tests/unit/test_synthesis/test_generator.py
@@ -100,6 +100,23 @@ class TestReadCorpus:
         result = _read_corpus(tmp_path)
         assert result == []
 
+    def test_read_file_with_encoding_error(self, tmp_path: Path) -> None:
+        """Test reading a file with invalid UTF-8 encoding raises error."""
+        # Create a file with invalid UTF-8 bytes
+        bad_file = tmp_path / "bad.txt"
+        bad_file.write_bytes(b"\xff\xfe\x00\x00")  # Invalid UTF-8
+
+        with pytest.raises(SynthesisExecutionError, match="Failed to read"):
+            _read_corpus(tmp_path)
+
+    def test_read_single_file_with_encoding_error(self, tmp_path: Path) -> None:
+        """Test reading a single file with invalid UTF-8 raises error."""
+        bad_file = tmp_path / "bad.txt"
+        bad_file.write_bytes(b"\xff\xfe\x00\x00")  # Invalid UTF-8
+
+        with pytest.raises(SynthesisExecutionError, match="Failed to read corpus file"):
+            _read_corpus(bad_file)
+
 
 class TestSyntheticDataGenerator:
     """Tests for SyntheticDataGenerator."""


### PR DESCRIPTION
## Summary

Fix `_read_corpus` in `openagent_eval/synthesis/generator.py` to stop silently swallowing file reading errors. Previously, when reading a corpus directory, any file that failed to read (e.g., invalid UTF-8 encoding) would only log a warning and continue, leaving the caller unaware that files were skipped.

## Changes

- `openagent_eval/synthesis/generator.py`: Modified `_read_corpus` to collect all file reading failures and raise `SynthesisExecutionError` with detailed error information (file paths and error messages) if any files fail to read. Single-file reads now also wrap errors in `SynthesisExecutionError` with the original error and path details.

## Testing

- Added `test_read_file_with_encoding_error` — verifies directory with invalid UTF-8 file raises `SynthesisExecutionError`
- Added `test_read_single_file_with_encoding_error` — verifies single invalid UTF-8 file raises `SynthesisExecutionError`
- All 20 generator tests pass
- All 68 synthesis tests pass

## Checklist

- [x] Tests added for the bug fix
- [x] All existing tests pass
- [x] Follows project coding standards
- [x] No breaking changes to public API