### PR TITLE
fix(corpus): normalize naive staleness timestamps

### DIFF
--- a/openagent_eval/corpus/staleness.py
+++ b/openagent_eval/corpus/staleness.py
@@ -7,7 +7,7 @@ and content freshness signals.
 from __future__ import annotations
 
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from typing import Any
 
 from openagent_eval.corpus.base import BaseCorpusAnalyzer
@@ -172,6 +172,8 @@ class StalenessDetector(BaseCorpusAnalyzer):
                 continue
 
             if isinstance(value, datetime):
+                if value.tzinfo is None:
+                    return value.replace(tzinfo=UTC)
                 return value
 
             if isinstance(value, str):

--- a/tests/unit/test_corpus/test_staleness.py
+++ b/tests/unit/test_corpus/test_staleness.py
@@ -60,6 +60,20 @@ class TestStalenessDetector:
         assert "stale.txt" in report.issues[0].document_ids
 
     @pytest.mark.asyncio
+    async def test_naive_metadata_datetime_is_treated_as_utc(self, detector):
+        """Test that naive metadata datetimes do not fail UTC comparisons."""
+        doc = CorpusDocument(
+            doc_id="naive.txt",
+            content="Old content.",
+            metadata={"last_modified": datetime(2020, 1, 15)},
+        )
+
+        report = await detector.analyze([doc])
+
+        assert len(report.issues) == 1
+        assert report.issues[0].metadata["last_updated"].endswith("+00:00")
+
+    @pytest.mark.asyncio
     async def test_health_score_decreases_with_staleness(self, detector, recent_doc, stale_doc):
         """Test health score decreases with more stale documents."""
         # All recent = perfect score


### PR DESCRIPTION
## Description

Normalize timezone-naive document metadata timestamps to UTC before comparing them with the staleness cutoff, preventing a `TypeError` during corpus audits.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] CI/CD update

## Related Issues

Closes #60

## How Has This Been Tested?

Added a regression test using a naive `datetime`; it fails on `main` and passes with this fix. All 10 staleness tests pass.

- [x] Unit tests pass (`uv run pytest`)
- [ ] Linter passes (`uv run ruff check .`)
- [ ] Type checker passes (`uv run mypy openagent_eval/`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A

## Additional Notes

Changed-file Ruff findings and formatting results are unchanged from `main`.
