### PR TITLE
fix(synthesis): Strategy 0 in _parse_response returns prematurely on single JSON objects (#94)

### DIFF
--- a/openagent_eval/synthesis/adversarial.py
+++ b/openagent_eval/synthesis/adversarial.py
@@ -405,7 +405,7 @@ class AdversarialTestCaseGenerator:
         questions = question_pattern.findall(text)
         answers = answer_pattern.findall(text)
 
-        for q, a in zip(questions, answers):
+        for q, a in zip(questions, answers, strict=False):
             _add_test_case(q, a)
 
         if test_cases:

--- a/openagent_eval/synthesis/adversarial.py
+++ b/openagent_eval/synthesis/adversarial.py
@@ -294,6 +294,22 @@ class AdversarialTestCaseGenerator:
         import re as _re
 
         test_cases: list[TestCase] = []
+        seen_questions: set[str] = set()
+
+        def _add_test_case(question: str, answer: str) -> None:
+            """Add test case if question not already seen."""
+            if question and question not in seen_questions:
+                seen_questions.add(question)
+                test_cases.append(
+                    TestCase(
+                        question=question,
+                        ground_truth=answer,
+                        context=context,
+                        test_type=test_type,
+                        source_document=source_document,
+                        chunk_index=chunk_index,
+                    )
+                )
 
         # Clean code blocks and normalize text
         text = raw_response.strip()
@@ -312,20 +328,10 @@ class AdversarialTestCaseGenerator:
         try:
             data = json.loads(text)
             if isinstance(data, dict):
-                question = data.get("question", "").strip()
-                answer = data.get("answer", "").strip()
-                if question:
-                    test_cases.append(
-                        TestCase(
-                            question=question,
-                            ground_truth=answer,
-                            context=context,
-                            test_type=test_type,
-                            source_document=source_document,
-                            chunk_index=chunk_index,
-                        )
-                    )
-                    return test_cases
+                question = data.get("question", "")
+                answer = data.get("answer", "")
+                _add_test_case(question, answer)
+                # Don't return here - continue to other strategies to find more questions
         except (json.JSONDecodeError, ValueError):
             pass
 
@@ -347,19 +353,9 @@ class AdversarialTestCaseGenerator:
             if isinstance(data, list):
                 for item in data:
                     if isinstance(item, dict):
-                        question = item.get("question", "").strip()
-                        answer = item.get("answer", "").strip()
-                        if question:
-                            test_cases.append(
-                                TestCase(
-                                    question=question,
-                                    ground_truth=answer,
-                                    context=context,
-                                    test_type=test_type,
-                                    source_document=source_document,
-                                    chunk_index=chunk_index,
-                                )
-                            )
+                        question = item.get("question", "")
+                        answer = item.get("answer", "")
+                        _add_test_case(question, answer)
                 if test_cases:
                     return test_cases
         except (json.JSONDecodeError, ValueError):
@@ -378,19 +374,9 @@ class AdversarialTestCaseGenerator:
                     obj_str = _re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]", "", obj_str)
 
                     item = json.loads(obj_str)
-                    question = item.get("question", "").strip()
-                    answer = item.get("answer", "").strip()
-                    if question:
-                        test_cases.append(
-                            TestCase(
-                                question=question,
-                                ground_truth=answer,
-                                context=context,
-                                test_type=test_type,
-                                source_document=source_document,
-                                chunk_index=chunk_index,
-                            )
-                        )
+                    question = item.get("question", "")
+                    answer = item.get("answer", "")
+                    _add_test_case(question, answer)
                 except (json.JSONDecodeError, ValueError):
                     continue
 
@@ -407,19 +393,7 @@ class AdversarialTestCaseGenerator:
         matches = qa_pattern.findall(text)
 
         for question, answer in matches:
-            question = question.strip()
-            answer = answer.strip()
-            if question:
-                test_cases.append(
-                    TestCase(
-                        question=question,
-                        ground_truth=answer,
-                        context=context,
-                        test_type=test_type,
-                        source_document=source_document,
-                        chunk_index=chunk_index,
-                    )
-                )
+            _add_test_case(question, answer)
 
         if test_cases:
             return test_cases
@@ -432,19 +406,7 @@ class AdversarialTestCaseGenerator:
         answers = answer_pattern.findall(text)
 
         for q, a in zip(questions, answers):
-            q = q.strip()
-            a = a.strip()
-            if q:
-                test_cases.append(
-                    TestCase(
-                        question=q,
-                        ground_truth=a,
-                        context=context,
-                        test_type=test_type,
-                        source_document=source_document,
-                        chunk_index=chunk_index,
-                    )
-                )
+            _add_test_case(q, a)
 
         if test_cases:
             return test_cases

--- a/openagent_eval/synthesis/question_gen.py
+++ b/openagent_eval/synthesis/question_gen.py
@@ -262,7 +262,7 @@ class QuestionGenerator:
         questions = question_pattern.findall(text)
         answers = answer_pattern.findall(text)
 
-        for q, a in zip(questions, answers):
+        for q, a in zip(questions, answers, strict=False):
             q = q.strip()
             a = a.strip()
             if q and a:

--- a/openagent_eval/synthesis/question_gen.py
+++ b/openagent_eval/synthesis/question_gen.py
@@ -145,6 +145,22 @@ class QuestionGenerator:
         import re as _re
 
         test_cases: list[TestCase] = []
+        seen_questions: set[str] = set()
+
+        def _add_test_case(question: str, answer: str) -> None:
+            """Add test case if question not already seen."""
+            if question and question not in seen_questions:
+                seen_questions.add(question)
+                test_cases.append(
+                    TestCase(
+                        question=question,
+                        ground_truth=answer,
+                        context=context,
+                        test_type=TestCaseType.STANDARD,
+                        source_document=source_document,
+                        chunk_index=chunk_index,
+                    )
+                )
 
         # Clean code blocks and normalize text
         text = raw_response.strip()
@@ -166,17 +182,8 @@ class QuestionGenerator:
                 question = data.get("question", "").strip()
                 answer = data.get("answer", "").strip()
                 if question and answer:
-                    test_cases.append(
-                        TestCase(
-                            question=question,
-                            ground_truth=answer,
-                            context=context,
-                            test_type=TestCaseType.STANDARD,
-                            source_document=source_document,
-                            chunk_index=chunk_index,
-                        )
-                    )
-                    return test_cases
+                    _add_test_case(question, answer)
+                    # Don't return here - continue to other strategies to find more questions
         except (json.JSONDecodeError, ValueError):
             pass
 
@@ -201,16 +208,7 @@ class QuestionGenerator:
                         question = item.get("question", "").strip()
                         answer = item.get("answer", "").strip()
                         if question and answer:
-                            test_cases.append(
-                                TestCase(
-                                    question=question,
-                                    ground_truth=answer,
-                                    context=context,
-                                    test_type=TestCaseType.STANDARD,
-                                    source_document=source_document,
-                                    chunk_index=chunk_index,
-                                )
-                            )
+                            _add_test_case(question, answer)
                 if test_cases:
                     return test_cases
         except (json.JSONDecodeError, ValueError):
@@ -232,16 +230,7 @@ class QuestionGenerator:
                     question = item.get("question", "").strip()
                     answer = item.get("answer", "").strip()
                     if question and answer:
-                        test_cases.append(
-                            TestCase(
-                                question=question,
-                                ground_truth=answer,
-                                context=context,
-                                test_type=TestCaseType.STANDARD,
-                                source_document=source_document,
-                                chunk_index=chunk_index,
-                            )
-                        )
+                        _add_test_case(question, answer)
                 except (json.JSONDecodeError, ValueError):
                     continue
 
@@ -261,16 +250,7 @@ class QuestionGenerator:
             question = question.strip()
             answer = answer.strip()
             if question and answer:
-                test_cases.append(
-                    TestCase(
-                        question=question,
-                        ground_truth=answer,
-                        context=context,
-                        test_type=TestCaseType.STANDARD,
-                        source_document=source_document,
-                        chunk_index=chunk_index,
-                    )
-                )
+                _add_test_case(question, answer)
 
         if test_cases:
             return test_cases
@@ -286,16 +266,7 @@ class QuestionGenerator:
             q = q.strip()
             a = a.strip()
             if q and a:
-                test_cases.append(
-                    TestCase(
-                        question=q,
-                        ground_truth=a,
-                        context=context,
-                        test_type=TestCaseType.STANDARD,
-                        source_document=source_document,
-                        chunk_index=chunk_index,
-                    )
-                )
+                _add_test_case(q, a)
 
         if test_cases:
             return test_cases


### PR DESCRIPTION
## Description

Fixes a bug in both `QuestionGenerator` and `AdversarialTestCaseGenerator` where Strategy 0 in `_parse_response` would parse a single JSON object (non-array LLM response), create ONE test case, and **return immediately** — instead of continuing to other strategies to find more questions.

**Root cause**: When the LLM returns a single JSON object like `{"question": "...", "answer": "..."}` instead of a JSON array, Strategy 0 would successfully parse it but then `return test_cases` prematurely, skipping Strategies 1-4 that could extract additional questions from the same response.

**Fix applied to both files**:
1. Removed the premature `return` in Strategy 0 — now it adds the test case and continues to other strategies
2. Added deduplication logic via `seen_questions` set and `_add_test_case` helper to prevent duplicates when multiple strategies find the same question

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Closes #94

## How Has This Been Tested?

- [x] Unit tests pass (`uv run pytest tests/unit/test_synthesis/ -v`)
- [x] Linter passes (`uv run ruff check .`)
- [x] Type checker passes (`uv run mypy openagent_eval/`)
- [x] Manual testing performed:
  - Single JSON object response → returns 1 question (no error, no premature return)
  - Multiple separate JSON objects → returns all questions (no duplicates)
  - Proper JSON array → returns all questions (works as before)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

All 69 synthesis tests pass. The fix is minimal and focused — only the `_parse_response` methods in `question_gen.py` and `adversarial.py` were modified.