### PR TITLE
docs: add environment variables reference page (fixes #111)

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,116 @@
+---
+tags:
+  - reference
+  - configuration
+---
+
+# Environment Variables
+
+OpenAgent Eval reads a small, fixed set of environment variables. None are
+required to import or install the package — they are consulted at runtime, and
+only for the provider or feature you actually use. Every variable listed here is
+read directly by OpenAgent Eval's own code; the file and line where each one is
+consumed is cited so you can trace the behaviour to source.
+
+Variables fall into two groups:
+
+- **[Provider API keys](#provider-api-keys)** — credentials for the hosted LLM
+  providers.
+- **[Configuration](#configuration)** — where OpenAgent Eval looks for your
+  config file.
+
+## Provider API keys
+
+Each hosted LLM provider reads its credential from a single environment
+variable. There is **no built-in default** for any key: if the key is neither
+passed explicitly (via the `api_key` config field or constructor argument) nor
+present in the environment, the provider raises `ProviderConnectionError` at
+initialisation.
+
+| Variable | Controls | Default | Example |
+| --- | --- | --- | --- |
+| `OPENAI_API_KEY` | API key for the `openai` LLM provider. | *unset* (no default) | `sk-proj-abc123…` |
+| `GEMINI_API_KEY` | API key for the `gemini` LLM provider (Google Gemini). | *unset* (no default) | `AIzaSy…` |
+| `ANTHROPIC_API_KEY` | API key for the `anthropic` LLM provider. | *unset* (no default) | `sk-ant-api03-…` |
+| `GROQ_API_KEY` | API key for the `groq` LLM provider. | *unset* (no default) | `gsk_…` |
+| `OPENROUTER_API_KEY` | API key for the `openrouter` LLM provider. | *unset* (no default) | `sk-or-v1-…` |
+
+**Precedence.** An `api_key` supplied in your `config.yaml` (or passed
+programmatically) takes priority; the environment variable is the fallback used
+only when no key is configured. For example, the OpenAI adapter resolves
+`config.api_key or os.getenv("OPENAI_API_KEY")`.
+
+**Where these are read:**
+
+| Variable | Consumed at |
+| --- | --- |
+| `OPENAI_API_KEY` | `openagent_eval/providers/llm/openai.py:111`, `:116` |
+| `GEMINI_API_KEY` | `openagent_eval/providers/llm/gemini.py:123` |
+| `ANTHROPIC_API_KEY` | `openagent_eval/providers/llm/anthropic.py:116` |
+| `GROQ_API_KEY` | `openagent_eval/providers/llm/groq.py:105`, `:111` |
+| `OPENROUTER_API_KEY` | `openagent_eval/providers/llm/openrouter.py:112` |
+
+The same five keys are also checked (without being consumed) by two
+diagnostics:
+
+- `oaeval doctor` reports each key's availability —
+  `openagent_eval/cli/commands/doctor.py:87–92`.
+- Config validation lists missing keys for the selected provider —
+  `openagent_eval/config/validator.py:74–79`.
+
+!!! note "No key required for local models"
+    The `ollama` and `mock` providers need no API key. Ollama's server URL is a
+    configuration/constructor value (`base_url`, default
+    `http://localhost:11434`), not an environment variable.
+
+## Configuration
+
+| Variable | Controls | Default | Example |
+| --- | --- | --- | --- |
+| `OAEVAL_CONFIG` | Absolute or relative path to the configuration file. When set and pointing at an existing file, it is used ahead of any auto-discovered `config.yaml`/`oaeval.yaml`. | *unset* (falls back to config auto-discovery) | `/etc/oaeval/config.yaml` |
+
+`OAEVAL_CONFIG` is the first entry in the config-discovery order (see
+[Config auto-discovery](cli.md#config-auto-discovery)). If it is set but the
+path does not exist, discovery returns no config rather than falling through to
+the directory search.
+
+**Where it is read:**
+
+- `openagent_eval/cli/utils/discovery.py:15`, `:33` (the resolution logic).
+- `openagent_eval/cli/commands/doctor.py:190` (reported by `oaeval doctor`).
+
+## How variables reach the process
+
+OpenAgent Eval reads variables straight from the process environment
+(`os.environ` / `os.getenv`). A few points worth knowing:
+
+!!! warning "The CLI does not auto-load `.env` files"
+    OpenAgent Eval does **not** depend on `python-dotenv`, and neither the
+    library nor the `oaeval` CLI loads a `.env` file automatically. To use a
+    `.env` file, export it into your shell first (for example
+    `set -a; . ./.env; set +a`) or rely on a runner that loads it for you.
+    The only place in the repository that parses `.env` directly is the
+    developer smoke-test script `scripts/run_real_eval.py:20–25`, which is not
+    part of the installed package.
+
+!!! warning "`${VAR}` in `config.yaml` is not expanded"
+    Values such as `api_key: ${OPENAI_API_KEY}` in a config file are **not**
+    interpolated — the config loader (`openagent_eval/config/loader.py`)
+    performs no environment-variable substitution, so the literal string
+    `${OPENAI_API_KEY}` would be used as the key. To read a key from the
+    environment, omit the `api_key` field entirely and let the provider fall
+    back to its environment variable.
+
+## Example: exporting keys
+
+```bash
+# Hosted providers — export only the ones you use.
+export OPENAI_API_KEY="sk-proj-abc123…"
+export ANTHROPIC_API_KEY="sk-ant-api03-…"
+
+# Point OpenAgent Eval at a specific config file.
+export OAEVAL_CONFIG="/etc/oaeval/config.yaml"
+
+oaeval doctor        # verify which keys are visible
+oaeval run           # config resolved via OAEVAL_CONFIG
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,6 +80,10 @@ OPENROUTER_API_KEY=...
     OpenAgent Eval supports fully local models through [Ollama](https://ollama.com).
     Set `provider: ollama` in your config and no API key is required.
 
+See the [Environment Variables](environment-variables.md) reference for every
+variable OpenAgent Eval reads, including how keys are resolved and how they
+reach the process.
+
 ## Next steps
 
 - Follow the [Quickstart](quickstart.md) to run your first evaluation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -178,6 +178,7 @@ nav:
   - Guide:
       - Architecture: architecture.md
       - CLI Reference: cli.md
+      - Environment Variables: environment-variables.md
       - API Reference: api.md
       - Report Output Formats: reports-output-formats.md
   - Examples:


### PR DESCRIPTION
Fixes #111.

Adds `docs/environment-variables.md` (nav: Guide section), plus a one-line pointer from `docs/installation.md`.

## How the table was built (evidence, not memory)

Searched every discovery mechanism, not just the issue's suggested greps: `os.getenv`/`os.environ` (6 project sites — the complete set), pydantic `BaseSettings`/`env_prefix`/`Field(env=…)`/alias forms (none exist), click/typer `envvar=` (none), dotenv (none in the package — only the dev script `scripts/run_real_eval.py` hand-parses `.env`), and `${VAR}`/expandvars config interpolation (none — the loader does not interpolate). Every documented variable carries its consuming site and its true default: the five provider keys (`OPENAI_API_KEY`, `GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY` — config `api_key` takes precedence, env is the fallback, unset raises `ProviderConnectionError`) and `OAEVAL_CONFIG` (first entry in config discovery order). No project variable is consumed only by a third-party SDK — every resolved key is passed to the SDK client explicitly — so there's no separate lib-consumed section to pad the page with.

The page also documents two behaviors users currently guess wrong (both verified against the code): the CLI does **not** auto-load `.env`, and `${OPENAI_API_KEY}`-style strings in `config.yaml` are **not** interpolated (the correct pattern — omit `api_key` and let the provider fall back to env — is shown instead).

## Gates

`mkdocs build --strict`: pass, zero warnings (replicated the docs CI env from `.github/workflows/docs.yml`; the toolchain isn't in the project extras). Docs-only diff — no code touched, test suite not applicable.

Heads-up: while building the table we found three pre-existing docs-vs-code mismatches (e.g. `installation.md` says `GOOGLE_API_KEY` but the code only reads `GEMINI_API_KEY`). Deliberately NOT fixed here to keep this PR to its issue — filed separately with details.

---
🤖 This PR was written with AI assistance (Claude), directed and verified by a human-supervised workflow.