### PR TITLE
fix(reports): respect ReportConfig.max_examples in HTML and JSON generators

### DIFF
--- a/openagent_eval/reports/html.py
+++ b/openagent_eval/reports/html.py
@@ -106,9 +106,10 @@ class HTMLReport(ReportGenerator):
             if numeric_metric_values else None
         )
 
-        # Format results for template
+        # Format results for template, respecting the configured example limit
+        max_examples = min(len(result.results), config.report.max_examples)
         results_data = []
-        for eval_result in result.results:
+        for eval_result in result.results[:max_examples]:
             results_data.append({
                 "question": eval_result.question,
                 "answer": eval_result.answer,

--- a/openagent_eval/reports/json_report.py
+++ b/openagent_eval/reports/json_report.py
@@ -87,8 +87,9 @@ class JSONReport(ReportGenerator):
             },
         }
 
-        # Format individual results
-        for eval_result in result.results:
+        # Format individual results, respecting the configured example limit
+        max_examples = min(len(result.results), config.report.max_examples)
+        for eval_result in result.results[:max_examples]:
             report_data["results"].append({
                 "question": eval_result.question,
                 "answer": eval_result.answer,

--- a/tests/unit/test_reports/conftest.py
+++ b/tests/unit/test_reports/conftest.py
@@ -128,6 +128,54 @@ def evaluation_report(
 
 
 @pytest.fixture
+def sample_config_limited() -> Config:
+    """Create a sample configuration with a low max_examples limit."""
+    return Config(
+        dataset=DatasetConfig(path="tests/sample_data/test_dataset.json"),
+        llm=LLMConfig(provider="openai", model="gpt-4o"),
+        retriever=RetrieverConfig(provider="chroma"),
+        metrics=MetricsConfig(
+            retrieval=["context_precision", "context_recall"],
+            generation=["faithfulness"],
+        ),
+        report=ReportConfig(
+            output=OutputFormat.TERMINAL,
+            output_dir="./test_reports",
+            max_examples=2,
+        ),
+    )
+
+
+@pytest.fixture
+def evaluation_report_limited(
+    sample_config_limited: Config,
+    pipeline_result_with_data: PipelineResult,
+) -> EvaluationReport:
+    """Create an EvaluationReport with max_examples below the result count."""
+    summary = {
+        "total_items": 5,
+        "successful_evaluations": 3,
+        "failed_evaluations": 2,
+        "metrics_summary": {
+            "precision": 0.85,
+            "recall": 0.8433,
+            "faithfulness": 0.8567,
+        },
+    }
+
+    return EvaluationReport(
+        config=sample_config_limited,
+        result=pipeline_result_with_data,
+        summary=summary,
+        metadata={
+            "version": "0.1.0",
+            "engine": "openagent-eval",
+            "title": "Test Report",
+        },
+    )
+
+
+@pytest.fixture
 def evaluation_report_empty(
     sample_config: Config,
     pipeline_result_empty: PipelineResult,

--- a/tests/unit/test_reports/test_html.py
+++ b/tests/unit/test_reports/test_html.py
@@ -67,6 +67,22 @@ class TestHTMLReport:
         assert "Sample Results" in result
         assert "What is Python?" in result
 
+    def test_generate_respects_max_examples(
+        self, evaluation_report_limited: Any
+    ) -> None:
+        """generate() includes at most config.report.max_examples results."""
+        report = HTMLReport()
+        captured_context: dict[str, Any] = {}
+
+        def _capture_context(context: dict[str, Any]) -> str:
+            captured_context.update(context)
+            return "ok"
+
+        report._render_template = _capture_context
+        report.generate(evaluation_report_limited)
+
+        assert len(captured_context["results"]) == 2
+
     def test_generate_contains_config(self, evaluation_report: Any) -> None:
         """generate() includes configuration."""
         report = HTMLReport()

--- a/tests/unit/test_reports/test_json_report.py
+++ b/tests/unit/test_reports/test_json_report.py
@@ -84,6 +84,15 @@ class TestJSONReport:
         assert data["failure_analysis"]["total_errors"] == 2
         assert "ProviderConnectionError" in data["failure_analysis"]["error_breakdown"]
 
+    def test_generate_respects_max_examples(
+        self, evaluation_report_limited: Any
+    ) -> None:
+        """generate() includes at most config.report.max_examples results."""
+        report = JSONReport()
+        result = report.generate(evaluation_report_limited)
+        data = json.loads(result)
+        assert len(data["results"]) == 2
+
     def test_generate_contains_configuration(
         self, evaluation_report: Any
     ) -> None:


### PR DESCRIPTION
## Summary

`ReportConfig.max_examples` was ignored by the HTML and JSON report generators, which emitted **all** evaluation results regardless of the configured limit. Terminal and Markdown generators already honored it, so behavior was inconsistent across output formats.

This makes all four generators respect `config.report.max_examples`, capping the number of example results included in the report.

## Changes

- `openagent_eval/reports/html.py`: slice `result.results` to `min(len(result.results), config.report.max_examples)` when building the template context.
- `openagent_eval/reports/json_report.py`: slice `result.results` to the same limit in the results loop.
- `tests/unit/test_reports/conftest.py`: add `sample_config_limited` / `evaluation_report_limited` fixtures with `max_examples=2` (fixture has 3 results).
- `tests/unit/test_reports/test_html.py`, `tests/unit/test_reports/test_json_report.py`: add tests asserting only `max_examples` results are emitted.

The pattern mirrors the existing `markdown.py` implementation (`max_examples = min(len(result.results), config.report.max_examples)`).

## Testing

- `pytest tests/unit/test_reports/` — 95 passed (includes 2 new tests).
- `ruff check` on changed source files — clean (no new violations).

## Checklist

- [x] Root cause identified (`html.py` / `json_report.py` ignored `config.report.max_examples`)
- [x] Fix applied to both generators
- [x] Tests added for the limit behavior
- [x] All report unit tests pass
- [x] Branch `fix/report-max-examples-respected` off `main`

Closes #88
