### PR TITLE
fix(providers): use async psycopg connection in pgvector retriever (#81)

### DIFF
--- a/openagent_eval/providers/retrievers/pgvector.py
+++ b/openagent_eval/providers/retrievers/pgvector.py
@@ -55,6 +55,7 @@ class PGVectorRetriever(Retriever):
         self._content_column = content_column
         self._embedding_column = embedding_column
         self._metric = metric
+        self._conn: Any = None
 
         try:
             import psycopg
@@ -64,8 +65,22 @@ class PGVectorRetriever(Retriever):
                 "Install it with: pip install openagent-eval[pgvector]"
             ) from exc
 
+    async def _ensure_connection(self) -> None:
+        """Lazily open the async Postgres connection on first use.
+
+        The async cursor API requires an :class:`psycopg.AsyncConnection`,
+        which can only be created with ``await``. We therefore defer
+        connection establishment out of ``__init__`` and into the async
+        ``retrieve`` path.
+        """
+        if self._conn is not None:
+            return
+        import psycopg
+
         try:
-            self._conn = psycopg.connect(self._dsn, autocommit=True)
+            self._conn = await psycopg.AsyncConnection.connect(
+                self._dsn, autocommit=True
+            )
         except Exception as exc:
             raise ProviderConnectionError(
                 message=f"Failed to connect to Postgres: {exc}",
@@ -76,6 +91,10 @@ class PGVectorRetriever(Retriever):
     async def retrieve(self, query: str, k: int = 5) -> list[Document]:
         """Embed the query and run a similarity SQL query."""
         self.validate_inputs(query=query, k=k)
+
+        # Connection failures must surface as ProviderConnectionError, not be
+        # swallowed into the query-execution error below.
+        await self._ensure_connection()
 
         try:
             vector = await self._embedder.embed_query(query)
@@ -124,3 +143,9 @@ class PGVectorRetriever(Retriever):
                 )
             )
         return documents
+
+    async def close(self) -> None:
+        """Close the underlying async connection if open."""
+        if self._conn is not None:
+            await self._conn.close()
+            self._conn = None

--- a/tests/unit/test_providers/test_pgvector_retriever.py
+++ b/tests/unit/test_providers/test_pgvector_retriever.py
@@ -1,0 +1,108 @@
+"""Tests for the pgvector retriever (issue #81).
+
+The retriever must use an async ``psycopg`` connection with the async cursor
+API. A synchronous ``psycopg.connect`` cannot be driven by ``await
+cur.execute(...)`` and crashes on the first query. These tests mock the
+``psycopg`` async surface so no real Postgres is required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from openagent_eval.exceptions.provider import ProviderConnectionError
+from openagent_eval.providers.embedders.base import Embedder
+from openagent_eval.providers.retrievers.pgvector import PGVectorRetriever
+
+
+class _FakeEmbedder(Embedder):
+    name = "fake"
+    description = "fake embedder for tests"
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+
+def _make_psycopg_mock() -> MagicMock:
+    """Build a fake ``psycopg`` module exposing an async connection.
+
+    ``AsyncConnection.connect`` is a coroutine returning a connection whose
+    ``cursor()`` is a *synchronous* method that returns an async context
+    manager (matching real ``psycopg`` async behaviour).
+    """
+    cursor = AsyncMock()
+    cursor.__aenter__.return_value = cursor
+    cursor.fetchall.return_value = [("doc text", 0.95)]
+
+    conn = AsyncMock()
+    conn.cursor = MagicMock(return_value=cursor)
+
+    psycopg = MagicMock()
+    psycopg.AsyncConnection.connect = AsyncMock(return_value=conn)
+    # A sync connect must NOT exist on the fake; the retriever must not call it.
+    return psycopg
+
+
+def _build_retriever() -> PGVectorRetriever:
+    return PGVectorRetriever(
+        table="docs",
+        embedder=_FakeEmbedder(),
+        dsn="postgresql://localhost/test",
+    )
+
+
+class TestPGVectorAsyncConnection:
+    async def test_retrieve_uses_async_connection(self):
+        psycopg = _make_psycopg_mock()
+
+        with patch.dict("sys.modules", {"psycopg": psycopg}):
+            retriever = _build_retriever()
+            docs = await retriever.retrieve("hello", k=3)
+
+        # Async connection was opened (not the sync blocking connect).
+        psycopg.AsyncConnection.connect.assert_awaited_once()
+        # The async cursor API was driven via await.
+        cursor = psycopg.AsyncConnection.connect.return_value.cursor.return_value
+        cursor.execute.assert_awaited_once()
+        cursor.fetchall.assert_awaited_once()
+        assert len(docs) == 1
+        assert docs[0].content == "doc text"
+        assert docs[0].score == 0.95
+
+    async def test_connection_is_lazy_and_cached(self):
+        psycopg = _make_psycopg_mock()
+
+        with patch.dict("sys.modules", {"psycopg": psycopg}):
+            retriever = _build_retriever()
+            # No connection before first retrieve.
+            assert retriever._conn is None
+            await retriever.retrieve("q1")
+            await retriever.retrieve("q2")
+
+        # Opened exactly once and reused across calls.
+        psycopg.AsyncConnection.connect.assert_awaited_once()
+        assert retriever._conn is not None
+
+    async def test_connection_failure_raises_typed_error(self):
+        psycopg = MagicMock()
+        psycopg.AsyncConnection.connect = AsyncMock(
+            side_effect=RuntimeError("connection refused")
+        )
+
+        with patch.dict("sys.modules", {"psycopg": psycopg}):
+            retriever = _build_retriever()
+            with pytest.raises(ProviderConnectionError, match="Failed to connect"):
+                await retriever.retrieve("q")
+
+    async def test_close_terminates_connection(self):
+        psycopg = _make_psycopg_mock()
+
+        with patch.dict("sys.modules", {"psycopg": psycopg}):
+            retriever = _build_retriever()
+            await retriever.retrieve("q")
+            assert retriever._conn is not None
+            await retriever.close()
+            assert retriever._conn is None
+            psycopg.AsyncConnection.connect.return_value.close.assert_awaited_once()

--- a/uv.lock
+++ b/uv.lock
@@ -2361,7 +2361,7 @@ wheels = [
 
 [[package]]
 name = "openagent-eval"
-version = "0.4.4"
+version = "0.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Fixes #81 — the pgvector retriever crashed on the first query.

The retriever opened a **synchronous** `psycopg.connect()` connection but drove it with the **async** cursor API (`async with self._conn.cursor()` / `await cur.execute(...)`). A sync `psycopg.Connection` does not implement the async protocol, so the first `await cur.execute(...)` raised and the retriever never returned results.

## Root Cause

`openagent_eval/providers/retrievers/pgvector.py` mixed a blocking connection with the async cursor API:

- `__init__` called `psycopg.connect(self._dsn, autocommit=True)` (sync)
- `retrieve()` called `async with self._conn.cursor() as cur: await cur.execute(...)` (async)

These two APIs are incompatible — `psycopg` requires `AsyncConnection` to use the async cursor.

## Changes

- Replace `psycopg.connect()` with `await psycopg.AsyncConnection.connect(...)`.
- Defer connection establishment into a lazy `_ensure_connection()` helper called from `retrieve()`. This keeps `__init__` non-blocking (no I/O in the constructor) and is consistent with the project's async-native rule (AGENT.md Core Rules).
- Connection failures now surface as `ProviderConnectionError` instead of being swallowed and re-wrapped as `ProviderExecutionError`.
- Add `close()` to terminate the async connection.

## Testing

Added `tests/unit/test_providers/test_pgvector_retriever.py` (4 tests, no real Postgres required — the `psycopg` async surface is mocked):

- `test_retrieve_uses_async_connection` — verifies `AsyncConnection.connect` is awaited and the cursor is driven via `await`.
- `test_connection_is_lazy_and_cached` — connection is opened once on first `retrieve()` and reused.
- `test_connection_failure_raises_typed_error` — connection errors raise `ProviderConnectionError`.
- `test_close_terminates_connection` — `close()` tears down the connection.

All 4 pass.

## Notes

- No public API change; `PGVectorRetriever` constructor signature is unchanged.
- Docs (`docs/providers/retrievers/pgvector.md`) do not reference the connection mode, so no doc update is needed.
- Pre-existing `ruff` TC001/F401 notices on `Embedder`/`psycopg` imports are consistent with sibling retrievers (e.g. `qdrant.py`) and are not introduced by this change.

## Checklist

- [x] Branch off `main` (never develop on `main`)
- [x] Typed exceptions used (no generic `Exception`)
- [x] External dependency mocked in tests
- [x] `ruff` clean for introduced code (matches existing retriever conventions)
