### PR TITLE
fix(reports): add extension handling to TerminalReport.generate_to_file (#83)

### DIFF
--- a/openagent_eval/reports/terminal.py
+++ b/openagent_eval/reports/terminal.py
@@ -107,7 +107,12 @@ class TerminalReport(ReportGenerator):
         Returns:
             Path to the written file.
         """
-        path = self._prepare_output_file(output_path)
+        path = Path(output_path)
+        if path.suffix == "":
+            path = path / "report.txt"
+        elif path.suffix.lower() != ".txt":
+            path = path.with_suffix(".txt")
+        path = self._prepare_output_file(path)
         content = self.generate(report)
         path.write_text(content, encoding="utf-8")
         return path

--- a/tests/unit/test_reports/test_terminal.py
+++ b/tests/unit/test_reports/test_terminal.py
@@ -75,11 +75,48 @@ class TestTerminalReport:
     ) -> None:
         """generate_to_file() creates parent directories."""
         report = TerminalReport()
-        output_path = tmp_path / "subdir" / "report.txt"
+        output_path = Path(tmp_path / "subdir" / "report.txt")
         result_path = report.generate_to_file(evaluation_report, output_path)
 
         assert result_path.exists()
         assert result_path.parent.exists()
+
+    def test_generate_to_file_defaults_to_txt(
+        self, evaluation_report: Any, tmp_path: Path
+    ) -> None:
+        """generate_to_file() appends report.txt when no extension is given."""
+        report = TerminalReport()
+        output_path = tmp_path / "my_report"
+        result_path = report.generate_to_file(evaluation_report, output_path)
+
+        assert result_path.name == "report.txt"
+        assert result_path.exists()
+        content = result_path.read_text(encoding="utf-8")
+        assert "SUMMARY" in content
+
+    def test_generate_to_file_normalizes_wrong_suffix(
+        self, evaluation_report: Any, tmp_path: Path
+    ) -> None:
+        """generate_to_file() normalizes a non-.txt suffix to .txt."""
+        report = TerminalReport()
+        output_path = tmp_path / "my_report.log"
+        result_path = report.generate_to_file(evaluation_report, output_path)
+
+        assert result_path.suffix.lower() == ".txt"
+        assert result_path.exists()
+        content = result_path.read_text(encoding="utf-8")
+        assert "SUMMARY" in content
+
+    def test_generate_to_file_keeps_txt_suffix(
+        self, evaluation_report: Any, tmp_path: Path
+    ) -> None:
+        """generate_to_file() preserves an explicit .txt path."""
+        report = TerminalReport()
+        output_path = tmp_path / "explicit.txt"
+        result_path = report.generate_to_file(evaluation_report, output_path)
+
+        assert result_path.name == "explicit.txt"
+        assert result_path.exists()
 
     def test_print_report(
         self, evaluation_report: Any, tmp_path: Path


### PR DESCRIPTION
## Summary

`TerminalReport.generate_to_file` wrote the raw `output_path` with **no extension logic**, while every other report generator applies consistent extension handling:

- `MarkdownReport` -> defaults to `report.md`
- `JSONReport` -> defaults to `report.json`
- `HTMLReport` -> defaults to `report.html` **and** normalizes a wrong suffix to `.html`
- `ComparisonReport` -> defaults to `comparison.txt`

This inconsistency meant a call like `generate_to_file(report, "my_run")` produced a file named `my_run` with no extension, unlike the other formats. The terminal test even hard-coded `report.txt`, masking the gap. (issue #83)

## Changes

**`openagent_eval/reports/terminal.py`** — `generate_to_file` now mirrors the HTML generator's robust pattern:

```python
path = Path(output_path)
if path.suffix == "":
    path = path / "report.txt"
elif path.suffix.lower() != ".txt":
    path = path.with_suffix(".txt")
path = self._prepare_output_file(path)
```

Behavior:
- No extension -> appends `report.txt`
- Wrong extension (e.g. `.log`) -> normalized to `.txt`
- Explicit `.txt` -> preserved as-is

**`tests/unit/test_reports/test_terminal.py`** — added three tests covering default, normalization, and passthrough paths.

## Testing

- `uv run pytest tests/unit/test_reports/` -> **98 passed**
- `uv run ruff check` on changed files -> **clean**
- New cases: `test_generate_to_file_defaults_to_txt`, `test_generate_to_file_normalizes_wrong_suffix`, `test_generate_to_file_keeps_txt_suffix`

## Checklist

- [x] Fix matches the extension-handling pattern of other generators
- [x] Unit tests added for success + edge (wrong suffix) paths
- [x] `ruff` passes
- [x] Full `reports` test suite passes (no regressions)
- [x] Branch `fix/83-terminal-report-extension` off `main`, not developed on `main`
