### PR TITLE
fix(exceptions): rename InvalidDatasetError.format to data_format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,6 @@ tiktoken-docs.md
 config.yaml
 config.groq.yaml
 config.*.yaml
+
+# Generated eval report artifacts
+reports/

--- a/openagent_eval/datasets/csv_loader.py
+++ b/openagent_eval/datasets/csv_loader.py
@@ -65,7 +65,7 @@ class CSVDatasetLoader(BaseDatasetLoader):
             raise InvalidDatasetError(
                 message=f"Invalid CSV format: {e}",
                 dataset_path=str(path),
-                format="csv",
+                data_format="csv",
             ) from e
 
         return self._parse_rows(rows, path)

--- a/openagent_eval/datasets/factory.py
+++ b/openagent_eval/datasets/factory.py
@@ -80,7 +80,7 @@ def _get_loader(config: DatasetConfig) -> BaseDatasetLoader:
         raise InvalidDatasetError(
             message=f"Unsupported dataset format: '{config.format}'. "
             f"Supported formats: {list(_FORMAT_MAP.keys())}",
-            format=config.format,
+            data_format=config.format,
         )
 
     # Guard against directory paths, which have no usable extension and

--- a/openagent_eval/datasets/hf_loader.py
+++ b/openagent_eval/datasets/hf_loader.py
@@ -69,7 +69,7 @@ class HFDatasetLoader(BaseDatasetLoader):
                         "Install it with: pip install openagent-eval[datasets]"
                     ),
                     dataset_path=str(path),
-                    format="hf",
+                    data_format="hf",
                 ) from e
 
             try:
@@ -78,7 +78,7 @@ class HFDatasetLoader(BaseDatasetLoader):
                 raise InvalidDatasetError(
                     message=f"Failed to load HuggingFace dataset: {e}",
                     dataset_path=str(path),
-                    format="hf",
+                    data_format="hf",
                 ) from e
 
             return self._parse_hf_dataset(hf_dataset, path)
@@ -153,7 +153,7 @@ class HFDatasetLoader(BaseDatasetLoader):
                     "The 'datasets' package is required for HuggingFace dataset loading. "
                     "Install it with: pip install openagent-eval[datasets]"
                 ),
-                format="hf",
+                data_format="hf",
             ) from e
 
         try:
@@ -161,7 +161,7 @@ class HFDatasetLoader(BaseDatasetLoader):
         except Exception as e:
             raise InvalidDatasetError(
                 message=f"Failed to load dataset '{dataset_name}': {e}",
-                format="hf",
+                data_format="hf",
             ) from e
 
         # Convert to list and apply limit

--- a/openagent_eval/datasets/json_loader.py
+++ b/openagent_eval/datasets/json_loader.py
@@ -63,7 +63,7 @@ class JSONDatasetLoader(BaseDatasetLoader):
             raise InvalidDatasetError(
                 message=f"Invalid JSON in file: {e}",
                 dataset_path=str(path),
-                format="json",
+                data_format="json",
                 line_number=e.lineno,
             ) from e
 

--- a/openagent_eval/datasets/jsonl_loader.py
+++ b/openagent_eval/datasets/jsonl_loader.py
@@ -120,7 +120,7 @@ class JSONLDatasetLoader(BaseDatasetLoader):
                 raise InvalidDatasetError(
                     message=f"Invalid JSON on line {line_num}: {e}",
                     dataset_path=str(path),
-                    format="jsonl",
+                    data_format="jsonl",
                     line_number=line_num,
                 ) from e
 

--- a/openagent_eval/datasets/pdf_loader.py
+++ b/openagent_eval/datasets/pdf_loader.py
@@ -88,7 +88,7 @@ class PDFDatasetLoader(BaseDatasetLoader):
                     "Install it with: pip install openagent-eval[pdf]"
                 ),
                 dataset_path=str(path),
-                format="pdf",
+                data_format="pdf",
             ) from e
 
         try:
@@ -97,7 +97,7 @@ class PDFDatasetLoader(BaseDatasetLoader):
             raise InvalidDatasetError(
                 message=f"Failed to read PDF: {e}",
                 dataset_path=str(path),
-                format="pdf",
+                data_format="pdf",
             ) from e
 
         raw_items = self._extract_raw(reader, path)

--- a/openagent_eval/exceptions/dataset.py
+++ b/openagent_eval/exceptions/dataset.py
@@ -57,7 +57,7 @@ class InvalidDatasetError(DatasetError):
     """Raised when a dataset has invalid format or structure.
 
     Attributes:
-        format: The detected or expected format of the dataset.
+        data_format: The detected or expected format of the dataset.
         line_number: The line number where the error occurred (if applicable).
     """
 
@@ -65,7 +65,7 @@ class InvalidDatasetError(DatasetError):
         self,
         message: str,
         dataset_path: str | None = None,
-        format: str | None = None,
+        data_format: str | None = None,
         line_number: int | None = None,
         details: dict | None = None,
     ) -> None:
@@ -74,18 +74,18 @@ class InvalidDatasetError(DatasetError):
         Args:
             message: Human-readable error message.
             dataset_path: Path to the invalid dataset.
-            format: The detected or expected format.
+            data_format: The detected or expected format.
             line_number: The line number where the error occurred.
             details: Additional context about the error.
         """
         error_details = details or {}
-        if format:
-            error_details["format"] = format
+        if data_format:
+            error_details["format"] = data_format
         if line_number:
             error_details["line_number"] = line_number
 
         super().__init__(message=message, dataset_path=dataset_path, details=error_details)
-        self.format = format
+        self.data_format = data_format
         self.line_number = line_number
 
 

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -85,8 +85,8 @@ class TestDatasetError:
 
     def test_invalid_dataset_error(self) -> None:
         """Test invalid dataset error."""
-        error = InvalidDatasetError("Invalid format", format="json", line_number=10)
-        assert error.format == "json"
+        error = InvalidDatasetError("Invalid format", data_format="json", line_number=10)
+        assert error.data_format == "json"
         assert error.line_number == 10
 
     def test_validation_error(self) -> None:


### PR DESCRIPTION
## Summary

Resolves #70. `InvalidDatasetError` declared a constructor parameter named `format`, which shadows Python's built-in `format()`. This is a code-quality/footgun issue flagged by linters and confuses readers who expect `format` to be the builtin.

The parameter (and its `self.format` attribute) is renamed to `data_format` across the exception definition and every call site. The `details` dict key remains `"format"` since it is only a string payload key, not a Python identifier, so there is no shadowing concern and no change to the serialized error output.

## Changes

- `openagent_eval/exceptions/dataset.py` — rename `format` param/attribute/docstring to `data_format`.
- `openagent_eval/datasets/factory.py` — update `data_format=config.format` kwarg.
- `openagent_eval/datasets/json_loader.py`, `jsonl_loader.py`, `csv_loader.py`, `hf_loader.py`, `pdf_loader.py` — update `data_format=` kwargs at all raise sites.
- `tests/unit/test_exceptions.py` — update the `InvalidDatasetError` test to use `data_format=`.

## Testing

- `pytest tests/unit/test_exceptions.py` — 26 passed.
- `pytest tests/unit/test_datasets` — 83 passed. (The 4 `test_pdf_loader` failures are pre-existing and environmental: `pypdf` is not installed in this environment. The error output confirms the new kwarg is passed correctly: `InvalidDatasetError: ... (format=pdf, ...)`.)
- `ruff check openagent_eval/exceptions/dataset.py` — all checks passed. Remaining ruff warnings in `datasets/` are pre-existing and unrelated to this change.

## Checklist

- [x] Branch created off `main` (`fix/70-...`)
- [x] `InvalidDatasetError` no longer shadows the `format` built-in
- [x] All call sites updated
- [x] Tests updated and passing
- [x] Lint clean on changed exception module
