### PR TITLE
fix(exceptions): include diagnosis step in error details

### DIFF
--- a/openagent_eval/exceptions/diagnosis.py
+++ b/openagent_eval/exceptions/diagnosis.py
@@ -37,7 +37,11 @@ class DiagnosisExecutionError(DiagnosisError):
             details: Optional dictionary with additional error context.
             step: The diagnosis step that failed (e.g., "blame_attribution").
         """
-        super().__init__(message, details)
+        error_details = details or {}
+        if step is not None:
+            error_details["step"] = step
+
+        super().__init__(message, error_details)
         self.step = step
 
 

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -9,6 +9,7 @@ from openagent_eval.exceptions import (
     DatasetError,
     DatasetNotFoundError,
     DatasetValidationError,
+    DiagnosisExecutionError,
     InvalidDatasetError,
     MetricError,
     MetricExecutionError,
@@ -128,6 +129,17 @@ class TestMetricError:
         error = MetricTimeoutError("Timed out immediately", timeout_seconds=0.0)
         assert error.timeout_seconds == 0.0
         assert error.details["timeout_seconds"] == 0.0
+
+
+class TestDiagnosisError:
+    """Tests for diagnosis errors."""
+
+    def test_execution_error_includes_step_in_details(self) -> None:
+        """Test that the failed step is visible in error details."""
+        error = DiagnosisExecutionError("Failed", step="blame_attribution")
+
+        assert error.step == "blame_attribution"
+        assert error.details["step"] == "blame_attribution"
 
 
 class TestProviderError:


### PR DESCRIPTION
## Description

Include the failed diagnosis step in `DiagnosisExecutionError.details` so logs and rendered errors retain that context.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update
- [ ] CI/CD update

## Related Issues

Closes #69

## How Has This Been Tested?

The regression fails on the original source and passes with this fix. All 27 exception tests and changed-file Ruff checks pass.

- [x] Unit tests pass (`uv run pytest`)
- [x] Linter passes (`uv run ruff check .`)
- [ ] Type checker passes (`uv run mypy openagent_eval/`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A

## Additional Notes

Changed-file mypy reports the same two pre-existing bare-`dict` errors with and without this patch.
