### PR TITLE
fix(providers/ollama): align generate_with_usage with async interface

### DIFF
--- a/openagent_eval/providers/llm/ollama.py
+++ b/openagent_eval/providers/llm/ollama.py
@@ -249,12 +249,12 @@ class Ollama(LLMProvider):
             # Fallback to word-based approximation
             return len(text.split())
 
-    def generate_with_usage(self, prompt: str, **kwargs: Any) -> LLMResponse:
+    def generate_with_usage_sync(self, prompt: str, **kwargs: Any) -> LLMResponse:
         """Generate text and return a full LLMResponse synchronously.
 
-        This is a helper method that generates text and extracts token usage
-        from Ollama's response metadata. For async usage, call
-        generate_with_usage_async() directly.
+        This is a blocking helper for callers that are not running inside an
+        event loop. Async callers must use ``generate_with_usage`` (the
+        coroutine that every LLM provider exposes).
 
         Args:
             prompt: The input prompt.
@@ -265,7 +265,7 @@ class Ollama(LLMProvider):
 
         Note:
             This method is synchronous for convenience. For async contexts,
-            use generate_with_usage_async() instead.
+            use ``generate_with_usage`` instead.
         """
         # Build request payload
         model = kwargs.get("model", self._model)
@@ -337,13 +337,14 @@ class Ollama(LLMProvider):
             latency_ms=latency_ms,
         )
 
-    async def generate_with_usage_async(
-        self, prompt: str, **kwargs: Any
-    ) -> LLMResponse:
+    async def generate_with_usage(self, prompt: str, **kwargs: Any) -> LLMResponse:
         """Generate text and return a full LLMResponse asynchronously.
 
-        This method generates text and extracts token usage from Ollama's
-        response metadata for accurate cost tracking.
+        This is the canonical usage-returning entry point and matches the
+        ``async def generate_with_usage`` signature exposed by every other LLM
+        provider, so the evaluation pipeline can ``await`` it uniformly. It
+        generates text and extracts token usage from Ollama's response metadata
+        for accurate cost tracking.
 
         Args:
             prompt: The input prompt.
@@ -416,6 +417,17 @@ class Ollama(LLMProvider):
             provider=self.name,
             latency_ms=latency_ms,
         )
+
+    async def generate_with_usage_async(
+        self, prompt: str, **kwargs: Any
+    ) -> LLMResponse:
+        """Deprecated alias for :meth:`generate_with_usage`.
+
+        Retained for backward compatibility with callers written against the
+        old Ollama-only name. New code should ``await generate_with_usage``,
+        which matches every other provider.
+        """
+        return await self.generate_with_usage(prompt, **kwargs)
 
     async def close(self) -> None:
         """Close the HTTP client and clean up resources."""

--- a/tests/integration/test_pipeline/test_ollama_pipeline_regression.py
+++ b/tests/integration/test_pipeline/test_ollama_pipeline_regression.py
@@ -1,0 +1,68 @@
+"""Regression test for issue #194.
+
+The pipeline awaits ``self._llm.generate_with_usage(...)``. Every LLM provider
+exposes ``generate_with_usage`` as an ``async def`` except Ollama, where it was
+a plain synchronous ``def`` (the async twin lived under the differently named
+``generate_with_usage_async``). Awaiting the synchronous call raised a
+``TypeError`` that ``_generate``'s broad ``except Exception`` swallowed, so the
+pipeline returned an empty answer for every Ollama generation with no error
+surfaced.
+
+This test drives ``Pipeline._generate`` with a real ``Ollama`` provider whose
+HTTP client is mocked, and asserts a non-empty answer comes back. Before the
+fix it fails (empty string); after the fix it passes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openagent_eval.core.pipeline import Pipeline
+from openagent_eval.providers.llm.ollama import Ollama
+
+
+def _mock_generate_response() -> MagicMock:
+    """A MagicMock mimicking a successful httpx response from /api/generate."""
+    response = MagicMock()
+    response.raise_for_status = MagicMock(return_value=None)
+    response.json.return_value = {
+        "model": "llama3.2",
+        "response": "Paris is the capital of France.",
+        "done": True,
+        "prompt_eval_count": 10,
+        "eval_count": 15,
+    }
+    return response
+
+
+@pytest.mark.asyncio
+async def test_pipeline_generate_with_ollama_returns_non_empty_answer() -> None:
+    """Pipeline._generate must surface a real answer for the Ollama provider.
+
+    Regression for #194: the awaited ``generate_with_usage`` was synchronous on
+    Ollama, so the pipeline silently returned ``("", None, None)``.
+    """
+    provider = Ollama(model="llama3.2")
+    # Mock the async HTTP client so no network call is made.
+    provider._client.post = AsyncMock(return_value=_mock_generate_response())
+
+    # Build a Pipeline without a full Config; _generate only needs _llm and
+    # _build_prompt, so construct the instance directly and inject the provider.
+    pipeline = Pipeline.__new__(Pipeline)
+    pipeline._llm = provider
+
+    answer, usage, latency_ms = await pipeline._generate(
+        question="What is the capital of France?",
+        contexts=["France is a country in Europe. Its capital is Paris."],
+        ground_truth="Paris",
+    )
+
+    assert answer == "Paris is the capital of France.", (
+        "Expected a real Ollama answer; got an empty/incorrect answer, which "
+        "means the awaited generate_with_usage was not a coroutine (#194)."
+    )
+    assert usage is not None
+    assert usage.total_tokens == 25
+    assert latency_ms is not None and latency_ms >= 0.0

--- a/tests/unit/test_providers/test_ollama.py
+++ b/tests/unit/test_providers/test_ollama.py
@@ -239,7 +239,7 @@ class TestOllamaTokenCount:
 
 
 # ---------------------------------------------------------------------------
-# generate_with_usage() / generate_with_usage_async() tests
+# generate_with_usage() / generate_with_usage_sync() tests
 #
 # Regression for #78: both methods must return an ``LLMResponse`` (matching
 # every other LLM provider), not a ``tuple[str, TokenUsage]``.
@@ -250,7 +250,7 @@ class TestOllamaGenerateWithUsage:
     def test_generate_with_usage_returns_llm_response(
         self, provider: Ollama, mock_httpx_response, monkeypatch
     ):
-        """generate_with_usage() returns an LLMResponse with all fields."""
+        """generate_with_usage_sync() returns an LLMResponse with all fields."""
         import openagent_eval.providers.llm.ollama as ollama_module
 
         mock_client = MagicMock()
@@ -262,7 +262,7 @@ class TestOllamaGenerateWithUsage:
             ollama_module.httpx, "Client", MagicMock(return_value=client_cm)
         )
 
-        result = provider.generate_with_usage("Test prompt")
+        result = provider.generate_with_usage_sync("Test prompt")
 
         assert isinstance(result, LLMResponse)
         assert result.content == "Ollama response"
@@ -277,7 +277,7 @@ class TestOllamaGenerateWithUsage:
     def test_generate_with_usage_model_override(
         self, provider: Ollama, mock_httpx_response, monkeypatch
     ):
-        """generate_with_usage() reflects a per-call model override."""
+        """generate_with_usage_sync() reflects a per-call model override."""
         import openagent_eval.providers.llm.ollama as ollama_module
 
         mock_client = MagicMock()
@@ -289,7 +289,7 @@ class TestOllamaGenerateWithUsage:
             ollama_module.httpx, "Client", MagicMock(return_value=client_cm)
         )
 
-        result = provider.generate_with_usage("Test prompt", model="mistral")
+        result = provider.generate_with_usage_sync("Test prompt", model="mistral")
 
         assert isinstance(result, LLMResponse)
         assert result.model == "mistral"


### PR DESCRIPTION
Closes #194.

`Pipeline._generate` awaits `generate_with_usage`, but Ollama exposed that name as a synchronous method while keeping its coroutine under the Ollama-specific `generate_with_usage_async` name. The resulting `TypeError` was swallowed by the pipeline's broad exception handler, leaving every Ollama generation with an empty answer.

This aligns Ollama with the async interface used by the other providers, moves the blocking helper to `generate_with_usage_sync`, and retains the previous async name as a compatibility alias. The regression test drives the real pipeline path with Ollama's HTTP client mocked and proves a non-empty answer plus token usage are returned.

Verified locally with the Ollama provider tests, pipeline integration tests, and core engine tests: 40 passed. Ruff check and format are clean, and mypy reports no issues in the changed provider.
