### PR TITLE
fix: update opencode model to deepseek-v4-flash-free

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -30,4 +30,4 @@ jobs:
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
-          model: opencode/minimax-m2.5-free
+          model: opencode/deepseek-v4-flash-free


### PR DESCRIPTION
## Problem
The opencode.yml workflow was using an invalid model ID: opencode/minimax-m2.5-free

This caused the error:
`
Model not found: opencode/minimax-m2.5-free. Did you mean: minimax-m2.5, minimax-m2.7, deepseek-v4-flash-free?
`

## Solution
Updated model to opencode/deepseek-v4-flash-free which is a valid free model.

## Testing
After merge, the /oc commands should work without model errors.