### PR TITLE
fix: progress bar resets to 1/total_items on completion (#38)

### DIFF
--- a/openagent_eval/cli/commands/run.py
+++ b/openagent_eval/cli/commands/run.py
@@ -121,9 +121,9 @@ def run_command(
         progress.update(task, description="Loading dataset...")
         dataset_items = load_dataset_for_run(config)
         total_items = len(dataset_items)
-        progress.update(task, description=f"Loaded {total_items} items", completed=1, total=1)
+        progress.update(task, description=f"Loaded {total_items} items")
 
-        progress.update(task, description=f"Running evaluation ({total_items} items)...", total=total_items)
+        progress.update(task, description=f"Running evaluation ({total_items} items)...", total=total_items, completed=0)
         report = execute_evaluation(config, dataset_items)
         progress.update(task, completed=total_items)
 
@@ -143,7 +143,7 @@ def run_command(
             format_file = output_dir / f"{report_path.stem}{ext}"
             generator.generate_to_file(report, format_file)
 
-        progress.update(task, description="Complete!", completed=total_items)
+        progress.update(task, description="Complete!")
 
     elapsed = time.time() - start_time
 


### PR DESCRIPTION
## Problem

The progress bar briefly resets to `1/total_items` during the loading-to-evaluation transition in `oaeval run`.

**Root cause**: At line 124, `completed=1, total=1` marks the task "done". At line 126, `total` changes to `total_items` but `completed` stays at `1`, causing Rich to render `1/total_items`.

## Fix

3-line change in `openagent_eval/cli/commands/run.py`:

| Line | Before | After |
|------|--------|-------|
| 124 | `completed=1, total=1` | Removed (keep indeterminate during load) |
| 126 | `total=total_items` | `total=total_items, completed=0` (clean start) |
| 146 | `completed=total_items` | Removed (already set at line 128) |

## Verification

- `ruff check` - All checks passed
- `pytest tests/integration/test_cli_integration/test_run.py` - 4/4 passed (including `test_run_shows_progress`)

Fixes #38
