### PR TITLE
fix: use @latest for opencode action

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -4,6 +4,7 @@
 #
 # Trigger: pull_request → opened/synchronize/reopened/ready_for_review
 # Permissions: id-token: write, contents: read, pull-requests: write, issues: write
+# Model: opencode/deepseek-v4-flash-free (@latest)
 # ─────────────────────────────────────────────────────────────────────────────
 
 name: PR Review
@@ -38,7 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenCode PR Review
-        uses: anomalyco/opencode/github@v1
+        uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Fix

PR #202 was merged with `anomalyco/opencode/github@v1` which doesn't exist as a tag. This caused the AI Code Review workflow to fail.

Changes:
- `@v1` → `@latest` (the only valid version tag for this action)
