### PR TITLE
fix: use metadata parameter in ChunkingQualityAnalyzer (#65)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -38,6 +38,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Run OpenCode PR Review
         uses: anomalyco/opencode/github@latest
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **Chunking Metadata Usage** — `ChunkingQualityAnalyzer.analyze()` now uses the `metadata` parameter to perform more informed analysis: checks chunk size deviation from expected, detects excessive character overlap, and adjusts empty chunk thresholds (#65)
+
 ---
 
 ## [0.4.6] - 2026-07-17

--- a/openagent_eval/diagnosis/chunking.py
+++ b/openagent_eval/diagnosis/chunking.py
@@ -121,7 +121,7 @@ class ChunkingQualityAnalyzer:
                     )
 
         # If expected_overlap is provided, check for excessive character overlap
-        if expected_overlap is not None and expected_overlap > 0:
+        if expected_overlap is not None:
             for i in range(len(contexts)):
                 for j in range(i + 1, len(contexts)):
                     char_overlap = self._char_overlap(contexts[i], contexts[j])
@@ -162,7 +162,7 @@ class ChunkingQualityAnalyzer:
 
         if len(lengths) < 2:
             # Still check single chunk against expected size
-            if expected_chunk_size is not None and lengths:
+            if expected_chunk_size is not None and expected_chunk_size > 0 and lengths:
                 actual_len = lengths[0]
                 deviation = abs(actual_len - expected_chunk_size) / expected_chunk_size
                 if deviation > DEFAULT_MAX_SIZE_DEVIATION:
@@ -200,7 +200,7 @@ class ChunkingQualityAnalyzer:
             )
 
         # If expected_chunk_size is provided, check deviation from expected
-        if expected_chunk_size is not None:
+        if expected_chunk_size is not None and expected_chunk_size > 0:
             for idx, length in enumerate(lengths):
                 deviation = abs(length - expected_chunk_size) / expected_chunk_size
                 if deviation > DEFAULT_MAX_SIZE_DEVIATION:

--- a/openagent_eval/diagnosis/chunking.py
+++ b/openagent_eval/diagnosis/chunking.py
@@ -5,22 +5,28 @@ Detects issues with how documents are split into chunks, including:
 - Overlapping chunks (duplicate content in multiple chunks)
 - Inconsistent chunk sizes
 - Context gaps (missing information between chunks)
+
+Metadata keys (optional):
+    chunk_size: Expected chunk size in characters. Used for size deviation checks.
+    chunk_overlap: Expected overlap between chunks in characters. Used for overlap analysis.
+    chunking_strategy: Strategy name (e.g., "recursive", "fixed", "semantic").
 """
 
 from __future__ import annotations
 
 import re
+
 from openagent_eval.diagnosis.models import ChunkingIssue
 
-
 # ---------------------------------------------------------------------------
-# Thresholds
+# Thresholds (default values, overridden by metadata when available)
 # ---------------------------------------------------------------------------
 
-OVERLAP_SIMILARITY_THRESHOLD = 0.8  # Jaccard similarity for overlap detection
-MIN_CHUNK_LENGTH = 50  # minimum expected chunk length in characters
-MAX_CHUNK_LENGTH = 5000  # maximum expected chunk length in characters
-INCONSISTENCY_RATIO = 4.0  # max/min length ratio
+DEFAULT_OVERLAP_SIMILARITY_THRESHOLD = 0.8  # Jaccard similarity for overlap detection
+DEFAULT_MIN_CHUNK_LENGTH = 50  # minimum expected chunk length in characters
+DEFAULT_MAX_CHUNK_LENGTH = 5000  # maximum expected chunk length in characters
+DEFAULT_INCONSISTENCY_RATIO = 4.0  # max/min length ratio
+DEFAULT_MAX_SIZE_DEVIATION = 0.5  # max deviation from expected chunk_size (50%)
 
 
 class ChunkingQualityAnalyzer:
@@ -32,6 +38,13 @@ class ChunkingQualityAnalyzer:
         issues = analyzer.analyze(question, contexts)
         for issue in issues:
             print(issue.issue_type, issue.description)
+
+    With metadata for more informed analysis::
+
+        issues = analyzer.analyze(question, contexts, metadata={
+            "chunk_size": 512.0,
+            "chunk_overlap": 50.0,
+        })
     """
 
     def analyze(
@@ -46,6 +59,9 @@ class ChunkingQualityAnalyzer:
             question: The question that triggered retrieval.
             contexts: List of retrieved context strings.
             metadata: Optional metric scores for additional analysis.
+                Supported keys:
+                - ``chunk_size``: Expected chunk size in characters.
+                - ``chunk_overlap``: Expected overlap in characters.
 
         Returns:
             List of detected chunking issues.
@@ -55,23 +71,42 @@ class ChunkingQualityAnalyzer:
         if not contexts:
             return issues
 
-        issues.extend(self._check_overlap(question, contexts))
-        issues.extend(self._check_size_consistency(question, contexts))
-        issues.extend(self._check_empty_chunks(question, contexts))
+        # Extract metadata values (default to None if not provided)
+        expected_chunk_size = (
+            int(metadata["chunk_size"]) if metadata and "chunk_size" in metadata else None
+        )
+        expected_overlap = (
+            int(metadata["chunk_overlap"]) if metadata and "chunk_overlap" in metadata else None
+        )
+
+        issues.extend(self._check_overlap(question, contexts, expected_overlap))
+        issues.extend(self._check_size_consistency(question, contexts, expected_chunk_size))
+        issues.extend(self._check_empty_chunks(question, contexts, expected_chunk_size))
         issues.extend(self._check_content_gaps(question, contexts))
 
         return issues
 
     def _check_overlap(
-        self, question: str, contexts: list[str]
+        self,
+        question: str,
+        contexts: list[str],
+        expected_overlap: int | None = None,
     ) -> list[ChunkingIssue]:
-        """Detect overlapping chunks using Jaccard similarity."""
+        """Detect overlapping chunks using Jaccard similarity.
+
+        Args:
+            question: The question that triggered retrieval.
+            contexts: List of retrieved context strings.
+            expected_overlap: Expected overlap in characters from metadata.
+                When provided, also checks if actual character overlap is
+                significantly higher than expected (indicating redundant chunks).
+        """
         issues: list[ChunkingIssue] = []
 
         for i in range(len(contexts)):
             for j in range(i + 1, len(contexts)):
                 similarity = self._jaccard_similarity(contexts[i], contexts[j])
-                if similarity > OVERLAP_SIMILARITY_THRESHOLD:
+                if similarity > DEFAULT_OVERLAP_SIMILARITY_THRESHOLD:
                     issues.append(
                         ChunkingIssue(
                             question=question,
@@ -85,22 +120,71 @@ class ChunkingQualityAnalyzer:
                         )
                     )
 
+        # If expected_overlap is provided, check for excessive character overlap
+        if expected_overlap is not None and expected_overlap > 0:
+            for i in range(len(contexts)):
+                for j in range(i + 1, len(contexts)):
+                    char_overlap = self._char_overlap(contexts[i], contexts[j])
+                    # Flag if actual overlap is more than 3x expected
+                    if char_overlap > expected_overlap * 3:
+                        issues.append(
+                            ChunkingIssue(
+                                question=question,
+                                issue_type="excessive_overlap",
+                                description=(
+                                    f"Contexts {i + 1} and {j + 1} have "
+                                    f"excessive character overlap ({char_overlap} chars vs "
+                                    f"expected {expected_overlap} chars), "
+                                    f"indicating inefficient chunking."
+                                ),
+                                affected_contexts=[i, j],
+                            )
+                        )
+
         return issues
 
     def _check_size_consistency(
-        self, question: str, contexts: list[str]
+        self,
+        question: str,
+        contexts: list[str],
+        expected_chunk_size: int | None = None,
     ) -> list[ChunkingIssue]:
-        """Detect inconsistent chunk sizes."""
+        """Detect inconsistent chunk sizes.
+
+        Args:
+            question: The question that triggered retrieval.
+            contexts: List of retrieved context strings.
+            expected_chunk_size: Expected chunk size in characters from metadata.
+                When provided, checks if chunks deviate significantly from this size.
+        """
         issues: list[ChunkingIssue] = []
         lengths = [len(c) for c in contexts]
 
         if len(lengths) < 2:
+            # Still check single chunk against expected size
+            if expected_chunk_size is not None and lengths:
+                actual_len = lengths[0]
+                deviation = abs(actual_len - expected_chunk_size) / expected_chunk_size
+                if deviation > DEFAULT_MAX_SIZE_DEVIATION:
+                    issues.append(
+                        ChunkingIssue(
+                            question=question,
+                            issue_type="chunk_size_deviation",
+                            description=(
+                                f"Chunk size ({actual_len} chars) deviates significantly "
+                                f"from expected ({expected_chunk_size} chars, "
+                                f"{deviation:.0%} deviation)."
+                            ),
+                            affected_contexts=[0],
+                        )
+                    )
             return issues
 
         min_len = min(lengths)
         max_len = max(lengths)
 
-        if min_len > 0 and (max_len / min_len) > INCONSISTENCY_RATIO:
+        # Check for inconsistent chunk sizes
+        if min_len > 0 and (max_len / min_len) > DEFAULT_INCONSISTENCY_RATIO:
             issues.append(
                 ChunkingIssue(
                     question=question,
@@ -115,17 +199,53 @@ class ChunkingQualityAnalyzer:
                 )
             )
 
+        # If expected_chunk_size is provided, check deviation from expected
+        if expected_chunk_size is not None:
+            for idx, length in enumerate(lengths):
+                deviation = abs(length - expected_chunk_size) / expected_chunk_size
+                if deviation > DEFAULT_MAX_SIZE_DEVIATION:
+                    issues.append(
+                        ChunkingIssue(
+                            question=question,
+                            issue_type="chunk_size_deviation",
+                            description=(
+                                f"Context {idx + 1} size ({length} chars) deviates "
+                                f"significantly from expected ({expected_chunk_size} chars, "
+                                f"{deviation:.0%} deviation)."
+                            ),
+                            affected_contexts=[idx],
+                        )
+                    )
+
         return issues
 
     def _check_empty_chunks(
-        self, question: str, contexts: list[str]
+        self,
+        question: str,
+        contexts: list[str],
+        expected_chunk_size: int | None = None,
     ) -> list[ChunkingIssue]:
-        """Detect empty or near-empty chunks."""
+        """Detect empty or near-empty chunks.
+
+        Args:
+            question: The question that triggered retrieval.
+            contexts: List of retrieved context strings.
+            expected_chunk_size: Expected chunk size in characters from metadata.
+                When provided, uses 10% of expected size as the threshold
+                for detecting empty/small chunks instead of the default.
+        """
         issues: list[ChunkingIssue] = []
+
+        # Use expected_chunk_size / 10 as threshold if provided
+        min_threshold = (
+            expected_chunk_size // 10
+            if expected_chunk_size is not None
+            else DEFAULT_MIN_CHUNK_LENGTH
+        )
 
         for i, ctx in enumerate(contexts):
             stripped = ctx.strip()
-            if len(stripped) < MIN_CHUNK_LENGTH:
+            if len(stripped) < min_threshold:
                 issues.append(
                     ChunkingIssue(
                         question=question,
@@ -189,6 +309,31 @@ class ChunkingQualityAnalyzer:
             )
 
         return issues
+
+    @staticmethod
+    def _char_overlap(text_a: str, text_b: str) -> int:
+        """Compute the length of the longest overlapping suffix/prefix between two texts.
+
+        This measures character-level overlap that might indicate inefficient
+        chunking (e.g., the same paragraph appears at the end of one chunk
+        and the beginning of the next).
+
+        Args:
+            text_a: First text.
+            text_b: Second text.
+
+        Returns:
+            Number of characters in the longest suffix of text_a that
+            matches a prefix of text_b.
+        """
+        max_overlap = min(len(text_a), len(text_b))
+        # Check from longest possible overlap down to 1
+        for length in range(max_overlap, 0, -1):
+            if text_a.endswith(text_b[:length]):
+                return length
+            if text_b.endswith(text_a[:length]):
+                return length
+        return 0
 
     @staticmethod
     def _jaccard_similarity(text_a: str, text_b: str) -> float:

--- a/tests/unit/test_diagnosis/test_chunking.py
+++ b/tests/unit/test_diagnosis/test_chunking.py
@@ -107,6 +107,159 @@ class TestChunkingQualityAnalyzer:
         assert len(issue_types) >= 1  # At least overlap
 
 
+class TestMetadataUsage:
+    """Tests for metadata parameter usage in ChunkingQualityAnalyzer."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        self.analyzer = ChunkingQualityAnalyzer()
+
+    def test_metadata_chunk_size_single_deviation(self) -> None:
+        """Chunk deviating from expected size should be flagged."""
+        # Expected 512, actual is 100 (80% deviation)
+        issues = self.analyzer.analyze(
+            "What is Python?",
+            ["Python is a language."],
+            metadata={"chunk_size": 512.0},
+        )
+        size_issues = [i for i in issues if i.issue_type == "chunk_size_deviation"]
+        assert len(size_issues) > 0
+        assert "512" in size_issues[0].description
+
+    def test_metadata_chunk_size_no_deviation(self) -> None:
+        """Chunk close to expected size should not be flagged."""
+        # Expected 20, actual is 20 (0% deviation)
+        issues = self.analyzer.analyze(
+            "What is Python?",
+            ["Python is a language."],
+            metadata={"chunk_size": 20.0},
+        )
+        size_issues = [i for i in issues if i.issue_type == "chunk_size_deviation"]
+        assert len(size_issues) == 0
+
+    def test_metadata_chunk_size_multiple_chunks(self) -> None:
+        """Multiple chunks with mixed deviations should be flagged."""
+        issues = self.analyzer.analyze(
+            "What is Python?",
+            ["Short.", "This is a much longer chunk that exceeds the expected size significantly."],
+            metadata={"chunk_size": 20.0},
+        )
+        size_issues = [i for i in issues if i.issue_type == "chunk_size_deviation"]
+        # Both chunks deviate from expected size of 20
+        assert len(size_issues) > 0
+
+    def test_metadata_chunk_overlap_excessive(self) -> None:
+        """Excessive character overlap should be detected when metadata provided."""
+        # These have suffix/prefix overlap: "brown fox" (9 chars)
+        ctx_a = "the quick brown fox"
+        ctx_b = "brown fox jumps over"  # starts with "brown fox"
+        issues = self.analyzer.analyze(
+            "What is Python?",
+            [ctx_a, ctx_b],
+            metadata={"chunk_overlap": 1.0},  # Expected only 1 char, actual is 9
+        )
+        overlap_issues = [i for i in issues if i.issue_type == "excessive_overlap"]
+        assert len(overlap_issues) > 0
+
+    def test_metadata_chunk_overlap_no_excess(self) -> None:
+        """Overlap within expected range should not be flagged."""
+        ctx_a = "Python is a language."
+        ctx_b = "JavaScript is used for web."
+        issues = self.analyzer.analyze(
+            "What is programming?",
+            [ctx_a, ctx_b],
+            metadata={"chunk_overlap": 50.0},  # Expected 50 chars
+        )
+        overlap_issues = [i for i in issues if i.issue_type == "excessive_overlap"]
+        assert len(overlap_issues) == 0
+
+    def test_metadata_empty_chunk_uses_expected_size(self) -> None:
+        """Empty chunk detection should use expected size threshold."""
+        # With chunk_size=1000, threshold is 100 chars
+        issues = self.analyzer.analyze(
+            "What is Python?",
+            ["Hi", "Python is a programming language used for many things."],
+            metadata={"chunk_size": 1000.0},
+        )
+        empty_issues = [i for i in issues if i.issue_type == "empty_or_small_chunk"]
+        # "Hi" (2 chars) is below 100 char threshold
+        assert len(empty_issues) > 0
+
+    def test_metadata_none_backward_compatible(self) -> None:
+        """Passing None metadata should work exactly as before."""
+        issues_none = self.analyzer.analyze(
+            "What is Python?",
+            ["Python is a language."],
+            metadata=None,
+        )
+        issues_no_meta = self.analyzer.analyze(
+            "What is Python?",
+            ["Python is a language."],
+        )
+        assert len(issues_none) == len(issues_no_meta)
+
+    def test_metadata_empty_dict_backward_compatible(self) -> None:
+        """Passing empty metadata dict should work exactly as before."""
+        issues = self.analyzer.analyze(
+            "What is Python?",
+            ["Python is a language."],
+            metadata={},
+        )
+        # Should have no metadata-specific issues
+        metadata_issues = [
+            i for i in issues
+            if i.issue_type in ("chunk_size_deviation", "excessive_overlap")
+        ]
+        assert len(metadata_issues) == 0
+
+    def test_metadata_both_chunk_size_and_overlap(self) -> None:
+        """Both metadata keys should be usable simultaneously."""
+        # Overlapping contexts with size deviation (suffix/prefix match)
+        ctx_a = "the quick brown fox"
+        ctx_b = "brown fox jumps over"  # starts with "brown fox"
+        issues = self.analyzer.analyze(
+            "What is Python?",
+            [ctx_a, ctx_b],
+            metadata={"chunk_size": 500.0, "chunk_overlap": 1.0},
+        )
+        # Should detect size deviation (both ~20 chars vs expected 500)
+        # and excessive overlap (9 chars overlap vs expected 1)
+        issue_types = {i.issue_type for i in issues}
+        assert "chunk_size_deviation" in issue_types
+        assert "excessive_overlap" in issue_types
+
+
+class TestCharOverlap:
+    """Tests for the character overlap helper."""
+
+    def test_identical_texts(self) -> None:
+        """Identical texts should have full overlap."""
+        overlap = ChunkingQualityAnalyzer._char_overlap("hello", "hello")
+        assert overlap == 5
+
+    def test_suffix_prefix_match(self) -> None:
+        """Suffix of A matching prefix of B should be detected."""
+        overlap = ChunkingQualityAnalyzer._char_overlap(
+            "the cat sat", "cat sat on"
+        )
+        assert overlap == 7  # "cat sat"
+
+    def test_no_overlap(self) -> None:
+        """Disjoint texts should have zero overlap."""
+        overlap = ChunkingQualityAnalyzer._char_overlap("hello", "world")
+        assert overlap == 0
+
+    def test_empty_texts(self) -> None:
+        """Empty texts should have zero overlap."""
+        overlap = ChunkingQualityAnalyzer._char_overlap("", "")
+        assert overlap == 0
+
+    def test_one_empty(self) -> None:
+        """One empty text should have zero overlap."""
+        overlap = ChunkingQualityAnalyzer._char_overlap("hello", "")
+        assert overlap == 0
+
+
 class TestJaccardSimilarity:
     """Tests for the Jaccard similarity helper."""
 


### PR DESCRIPTION
## Summary

Fixes #65 — ChunkingQualityAnalyzer.analyze() now uses the metadata parameter for more informed chunking quality analysis.

## Changes

### Core Fix (openagent_eval/diagnosis/chunking.py)
- **Extract metadata values**: chunk_size and chunk_overlap are now read from the metadata dict
- **chunk_size_deviation check**: Flags chunks that deviate >50% from expected size
- **excessive_overlap check**: Flags character overlap >3x the expected overlap
- **Adaptive empty chunk threshold**: Uses chunk_size / 10 when chunk_size is provided instead of the default 50 chars
- **Added _char_overlap() helper**: Computes suffix/prefix character overlap between texts

### Tests (	ests/unit/test_diagnosis/test_chunking.py)
- 9 new tests in TestMetadataUsage covering all metadata scenarios
- 5 new tests in TestCharOverlap for the new helper method
- All backward compatible — metadata=None or {} works exactly as before

## Test Results
`
29/29 chunking tests passed
76/76 full diagnosis test suite passed
ruff check: clean
`

## Metadata Keys Supported
| Key | Type | Description |
|-----|------|-------------|
| chunk_size | loat | Expected chunk size in characters |
| chunk_overlap | loat | Expected overlap between chunks in characters |

**Full Changelog**: https://github.com/OpenAgentHQ/openagent-eval/compare/main...fix/65-chunking-metadata-unused