### PR TITLE
test: add regression test for mock provider (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **Mock Provider Regression** — `oaeval synth --llm-provider mock` now correctly uses `MockLLMProvider` instead of falling back to `OpenAIProvider`, preventing unexpected API key requirements and potential API costs (#40)
 - **Chunking Metadata Usage** — `ChunkingQualityAnalyzer.analyze()` now uses the `metadata` parameter to perform more informed analysis: checks chunk size deviation from expected, detects excessive character overlap, and adjusts empty chunk thresholds (#65)
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- **Mock Provider Regression** — `oaeval synth --llm-provider mock` now correctly uses `MockLLMProvider` instead of falling back to `OpenAIProvider`, preventing unexpected API key requirements and potential API costs (#40)
+- **Mock Provider Regression Test** — add regression test verifying that `--llm-provider mock` never falls back to `OpenAIProvider` (#40)
 - **Chunking Metadata Usage** — `ChunkingQualityAnalyzer.analyze()` now uses the `metadata` parameter to perform more informed analysis: checks chunk size deviation from expected, detects excessive character overlap, and adjusts empty chunk thresholds (#65)
 
 ---

--- a/tests/unit/test_cli/test_synth.py
+++ b/tests/unit/test_cli/test_synth.py
@@ -41,7 +41,7 @@ def test_create_provider_uses_offline_mock_provider() -> None:
     assert response.model == "synthetic-test-model"
 
 
-def test_mock_provider_never_instantiates_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_mock_provider_never_instantiates_openai() -> None:
     """Regression: --llm-provider mock must NOT create an OpenAI provider.
 
     Prior to the fix, the mock case fell back to OpenAIProvider, which

--- a/tests/unit/test_cli/test_synth.py
+++ b/tests/unit/test_cli/test_synth.py
@@ -41,6 +41,25 @@ def test_create_provider_uses_offline_mock_provider() -> None:
     assert response.model == "synthetic-test-model"
 
 
+def test_mock_provider_never_instantiates_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: --llm-provider mock must NOT create an OpenAI provider.
+
+    Prior to the fix, the mock case fell back to OpenAIProvider, which
+    required API keys and could incur real API costs.  This test verifies
+    that the OpenAI constructor is never called when provider='mock'.
+    """
+    from unittest.mock import patch
+
+    openai_init = patch(
+        "openagent_eval.providers.llm.openai.AsyncOpenAI", autospec=True
+    )
+    with openai_init as mock_openai_cls:
+        provider = _create_provider("mock", "test-model")
+
+    assert isinstance(provider, MockLLMProvider)
+    mock_openai_cls.assert_not_called()
+
+
 @pytest.fixture
 def fake_generator(monkeypatch: pytest.MonkeyPatch) -> dict:
     """Replace SyntheticDataGenerator so no LLM/network call is ever made.


### PR DESCRIPTION
## Summary

Adds an explicit regression test verifying that --llm-provider mock never instantiates an OpenAIProvider. 

The underlying bug (commit 8fed362) was already fixed by switching _create_provider() to use the factory pattern (get_llm_provider(config)), but lacked a test that directly asserts the OpenAI client is never constructed — only checking the return type.

## Changes

- **	ests/unit/test_cli/test_synth.py** — new 	est_mock_provider_never_instantiates_openai test that patches AsyncOpenAI and asserts it is never called when creating a mock provider
- **CHANGELOG.md** — documents the fix under [Unreleased] > Fixed

## Test Results

- 14/14 synth CLI tests pass (including new regression test)
- Lint: all checks pass
- 1 pre-existing unrelated failure (	est_audit_error_message_includes_path — Windows path-wrapping issue)

Closes #40