### PR TITLE
fix: use pull_request_target for fork PR reviews

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,7 +2,7 @@
 # PR Review Workflow for OpenAgentHQ
 # Automatically reviews PRs using OpenCode AI when opened or updated.
 #
-# Trigger: pull_request → opened/synchronize/reopened/ready_for_review
+# Trigger: pull_request_target → opened/synchronize/reopened/ready_for_review
 # Permissions: id-token: write, contents: read, pull-requests: write, issues: write
 # Model: opencode/deepseek-v4-flash-free (@latest)
 # ─────────────────────────────────────────────────────────────────────────────
@@ -10,7 +10,7 @@
 name: PR Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
 # Cancel in-progress reviews for the same PR
@@ -36,6 +36,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Configure git identity


### PR DESCRIPTION
## Summary
Changes the PR review workflow trigger from pull_request to pull_request_target to enable reviews on fork PRs.

## Changes
- Changed trigger from pull_request to pull_request_target
- Added explicit ef to checkout fork's commit SHA

## Why
The previous setup used pull_request which gives a read-only token for fork PRs, causing 403 errors when trying to post review comments. Using pull_request_target runs with the base repo's write token, allowing the AI to post reviews on all PRs.

## Security
- Only reads fork code (read-only)
- Only posts comments (no code execution)
- Follows same pattern as GitHub Copilot