### PR TITLE
fix: use OpenCode CLI directly for PR reviews

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -48,10 +48,8 @@ jobs:
         uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: opencode/deepseek-v4-flash-free
-          use_github_token: true
           prompt: |
             Review this pull request thoroughly. Provide a structured code review covering:
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -39,44 +39,45 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      - name: Configure git identity
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Install OpenCode
+        run: curl -fsSL https://opencode.ai/install | bash
 
       - name: Run OpenCode PR Review
-        uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-        with:
-          model: opencode/deepseek-v4-flash-free
-          prompt: |
-            Review this pull request thoroughly. Provide a structured code review covering:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REVIEW=$(opencode run --model opencode/deepseek-v4-flash-free --prompt "
+          Review this pull request thoroughly. Provide a structured code review covering:
 
-            ## Summary
-            Brief summary of what this PR does.
+          ## Summary
+          Brief summary of what this PR does.
 
-            ## Issues Found
-            For each issue found, categorize it:
-            - [BUG] — Logic errors, race conditions, edge cases
-            - [SECURITY] — Vulnerabilities, injection, secrets exposure
-            - [PERFORMANCE] — Inefficiency, N+1 queries, memory issues
-            - [STYLE] — Readability, naming, code organization
-            - [TEST] — Missing tests, weak assertions, coverage gaps
+          ## Issues Found
+          For each issue found, categorize it:
+          - [BUG] — Logic errors, race conditions, edge cases
+          - [SECURITY] — Vulnerabilities, injection, secrets exposure
+          - [PERFORMANCE] — Inefficiency, N+1 queries, memory issues
+          - [STYLE] — Readability, naming, code organization
+          - [TEST] — Missing tests, weak assertions, coverage gaps
 
-            Each issue should include:
-            - File path and line number
-            - Severity: LOW / MEDIUM / HIGH
-            - Description of the problem
-            - Suggested fix
+          Each issue should include:
+          - File path and line number
+          - Severity: LOW / MEDIUM / HIGH
+          - Description of the problem
+          - Suggested fix
 
-            ## Positive Notes
-            Highlight what was done well (good patterns, clean code, proper tests).
+          ## Positive Notes
+          Highlight what was done well (good patterns, clean code, proper tests).
 
-            ## Verdict
-            - APPROVE — No blocking issues
-            - COMMENT — Minor suggestions, no blockers
-            - REQUEST CHANGES — Blocking issues that must be fixed
+          ## Verdict
+          - APPROVE — No blocking issues
+          - COMMENT — Minor suggestions, no blockers
+          - REQUEST CHANGES — Blocking issues that must be fixed
 
-            Be specific and actionable. Reference actual code from the diff.
-            If no issues are found, say "No issues found. Good job!"
+          Be specific and actionable. Reference actual code from the diff.
+          If no issues are found, say 'No issues found. Good job!'
+          ")
+
+          # Post review as comment using GitHub CLI
+          gh pr comment ${{ github.event.pull_request.number }} --body "$REVIEW"


### PR DESCRIPTION
## Summary
Changes the PR review workflow to use OpenCode CLI directly instead of the GitHub Action.

## Why
The OpenCode GitHub Action has a hard-coded permission check that verifies the PR author has write access to the repo. External contributors (fork PRs) don't have write access, so the action fails before even trying to post comments.

## Solution
- Install OpenCode CLI directly
- Run opencode run to generate the review
- Post the review using gh pr comment with the workflow's GITHUB_TOKEN

This bypasses the permission check entirely and works for all PRs, including forks.