### PR TITLE
fix(nli): expose model_name property on NLIJudge

### DIFF
--- a/openagent_eval/metrics/generation/faithfulness.py
+++ b/openagent_eval/metrics/generation/faithfulness.py
@@ -135,7 +135,7 @@ class Faithfulness(BaseMetric):
                 "method": "nli",
                 "claims_total": len(claims),
                 "claims_supported": supported,
-                "model": judge._model_name,
+                "model": judge.model_name,
             },
         )
 

--- a/openagent_eval/metrics/generation/relevancy.py
+++ b/openagent_eval/metrics/generation/relevancy.py
@@ -129,7 +129,7 @@ class AnswerRelevancy(BaseMetric):
             metadata={
                 "method": "nli",
                 "label": result.label.value,
-                "model": judge._model_name,
+                "model": judge.model_name,
             },
         )
 

--- a/openagent_eval/metrics/nli/judge.py
+++ b/openagent_eval/metrics/nli/judge.py
@@ -77,6 +77,11 @@ class NLIJudge:
         self._pipeline: Any = None
 
     @property
+    def model_name(self) -> str:
+        """Public accessor for the configured HuggingFace model name."""
+        return self._model_name
+
+    @property
     def pipeline(self) -> Any:
         """Lazily load the NLI pipeline (heavy import)."""
         if self._pipeline is None:

--- a/tests/unit/test_metrics/test_nli.py
+++ b/tests/unit/test_metrics/test_nli.py
@@ -218,6 +218,11 @@ class TestNLIJudge:
     def setup_method(self):
         self.judge = NLIJudge(model_name="test-model")
 
+    def test_model_name_property(self):
+        assert self.judge.model_name == "test-model"
+        default_judge = NLIJudge()
+        assert default_judge.model_name == NLIJudge.DEFAULT_MODEL
+
     def test_empty_premise(self):
         result = self.judge.evaluate(premise="", hypothesis="test")
         assert result.label == NLILabel.NEUTRAL


### PR DESCRIPTION
## Description

Add a public `model_name` property on `NLIJudge` and update faithfulness/relevancy metrics to use it instead of accessing the private `_model_name` attribute.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Closes #73

## How Has This Been Tested?

- [x] Unit tests pass (`pytest tests/unit/test_metrics/test_nli.py` — 37/37 passed)
- [x] Linter passes on changed production files
- [ ] Type checker passes (`uv run mypy openagent_eval/`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

### Summary
Expose `NLIJudge.model_name` as a read-only public accessor and route faithfulness/relevancy metadata through it.

### Motivation
`Faithfulness` and `AnswerRelevancy` were reading `judge._model_name`, coupling metrics to private implementation details. A future `NLIJudge` refactor could silently break scoring via the broad `except Exception` fallback.

### Changes
- Add `@property model_name` on `NLIJudge`
- Replace `judge._model_name` with `judge.model_name` in `faithfulness.py` and `relevancy.py`
- Add `test_model_name_property` unit test

### Tests
```bash
pytest tests/unit/test_metrics/test_nli.py  # 37 passed
```

### Notes
- composer-2.5 review: **APPROVE**
- Minimal scope; no behavior change beyond using the public API