### PR TITLE
fix(diagnosis): return BlameTarget.NONE for healthy items instead of UNKNOWN

### DIFF
--- a/openagent_eval/cli/commands/diagnose.py
+++ b/openagent_eval/cli/commands/diagnose.py
@@ -32,6 +32,7 @@ _BLAME_LABELS: dict[str, str] = {
     BlameTarget.GENERATION.value: "[yellow]Generation[/yellow]",
     BlameTarget.CHUNKING.value: "[cyan]Chunking[/cyan]",
     BlameTarget.DATASET.value: "[magenta]Dataset[/magenta]",
+    BlameTarget.NONE.value: "[green]Healthy[/green]",
     BlameTarget.UNKNOWN.value: "[dim]Unknown[/dim]",
 }
 

--- a/openagent_eval/diagnosis/analyzer.py
+++ b/openagent_eval/diagnosis/analyzer.py
@@ -129,7 +129,7 @@ class DiagnosisAnalyzer:
                 all_chunking_issues.extend(chunking_issues)
 
             # Check if item is healthy
-            if blame_result.target == BlameTarget.UNKNOWN:
+            if blame_result.target == BlameTarget.NONE:
                 healthy_count += 1
 
         # Build recommendations

--- a/openagent_eval/diagnosis/blame.py
+++ b/openagent_eval/diagnosis/blame.py
@@ -225,8 +225,8 @@ class BlameAttribution:
         """Determine the primary blame target from all detected failures."""
         if not failures:
             return BlameResult(
-                target=BlameTarget.UNKNOWN,
-                confidence=0.0,
+                target=BlameTarget.NONE,
+                confidence=1.0,
                 reason="No failures detected.",
                 failure_modes=[],
             )

--- a/openagent_eval/diagnosis/models.py
+++ b/openagent_eval/diagnosis/models.py
@@ -31,12 +31,17 @@ class FailureMode(str, Enum):
 
 
 class BlameTarget(str, Enum):
-    """Which component is blamed for a failure."""
+    """Which component is blamed for a failure.
+
+    NONE indicates analysis completed with no failures detected.
+    UNKNOWN is reserved for cases where blame could not be determined.
+    """
 
     RETRIEVAL = "retrieval"
     GENERATION = "generation"
     CHUNKING = "chunking"
     DATASET = "dataset"
+    NONE = "none"
     UNKNOWN = "unknown"
 
 

--- a/tests/unit/test_diagnosis/test_blame.py
+++ b/tests/unit/test_diagnosis/test_blame.py
@@ -27,8 +27,8 @@ class TestBlameAttribution:
     # Healthy cases
     # ------------------------------------------------------------------
 
-    def test_healthy_item_returns_unknown(self) -> None:
-        """An item with good scores should return UNKNOWN blame."""
+    def test_healthy_item_returns_none(self) -> None:
+        """An item with good scores should return NONE blame (no failures)."""
         scores = ComponentScores(
             question="What is Python?",
             retrieval_scores={"context_precision": 0.9, "context_recall": 0.85},
@@ -38,7 +38,8 @@ class TestBlameAttribution:
             answer_length=500,
         )
         result = self.blamer.analyze(scores)
-        assert result.target == BlameTarget.UNKNOWN
+        assert result.target == BlameTarget.NONE
+        assert result.confidence == 1.0
         assert len(result.failure_modes) == 0
 
     def test_empty_scores_returns_empty_retrieval(self) -> None:
@@ -162,8 +163,8 @@ class TestBlameAttribution:
             answer_length=300,
         )
         result = self.blamer.analyze(scores)
-        # May blame chunking or unknown depending on thresholds
-        assert result.target in (BlameTarget.CHUNKING, BlameTarget.UNKNOWN)
+        # May blame chunking or none depending on thresholds
+        assert result.target in (BlameTarget.CHUNKING, BlameTarget.NONE)
 
     def test_uneven_context_lengths(self) -> None:
         """Highly uneven context lengths should detect chunking issue."""

--- a/tests/unit/test_diagnosis/test_integration.py
+++ b/tests/unit/test_diagnosis/test_integration.py
@@ -167,7 +167,7 @@ class TestDiagnosisPipeline:
             answer_length=200,
         )
         result = blamer.analyze(healthy)
-        assert result.target == BlameTarget.UNKNOWN
+        assert result.target == BlameTarget.NONE
 
         # Test empty retrieval
         empty = ComponentScores(

--- a/tests/unit/test_diagnosis/test_models.py
+++ b/tests/unit/test_diagnosis/test_models.py
@@ -38,9 +38,9 @@ class TestFailureMode:
 class TestBlameTarget:
     """Tests for BlameTarget enum."""
 
-    def test_has_five_targets(self) -> None:
-        """BlameTarget should have exactly 5 targets."""
-        assert len(BlameTarget) == 5
+    def test_has_six_targets(self) -> None:
+        """BlameTarget should have exactly 6 targets."""
+        assert len(BlameTarget) == 6
 
     def test_values(self) -> None:
         """BlameTarget values should be descriptive strings."""
@@ -48,6 +48,7 @@ class TestBlameTarget:
         assert BlameTarget.GENERATION.value == "generation"
         assert BlameTarget.CHUNKING.value == "chunking"
         assert BlameTarget.DATASET.value == "dataset"
+        assert BlameTarget.NONE.value == "none"
         assert BlameTarget.UNKNOWN.value == "unknown"
 
 


### PR DESCRIPTION
## Summary

When blame attribution finds no failures, it now returns `BlameTarget.NONE` (confidence 1.0) instead of `BlameTarget.UNKNOWN` (confidence 0.0). This separates "analysis succeeded, no issues" from "could not determine blame".

Fixes #67

## Motivation

`BlameTarget.UNKNOWN` implied indeterminate analysis, but was returned for healthy items with no failures. This semantic mismatch caused `DiagnosisAnalyzer` to count healthy items by checking `UNKNOWN`, which is confusing for API consumers and report readers.

## Changes

- Added `BlameTarget.NONE = "none"` enum value with docstring clarifying NONE vs UNKNOWN semantics
- `BlameAttribution._determine_blame()` returns `NONE` with confidence 1.0 when no failures are detected
- `DiagnosisAnalyzer` counts healthy items via `BlameTarget.NONE` instead of `UNKNOWN`
- CLI diagnose command displays `[green]Healthy[/green]` for NONE targets
- Updated unit and integration tests

## Tests

```
python3 -m pytest tests/unit/test_diagnosis/ -v
# 76 passed
```

## Notes

- `BlameTarget.UNKNOWN` is retained for future genuinely indeterminate cases but is not returned by `BlameAttribution.analyze()` today
- This is a behavioral change for SDK consumers who checked `target == BlameTarget.UNKNOWN` to detect healthy items; they should now check `BlameTarget.NONE`
