### PR TITLE
fix(core): export EvaluationReport, EvaluationResult, PipelineResult from core

### DIFF
--- a/openagent_eval/core/__init__.py
+++ b/openagent_eval/core/__init__.py
@@ -1,8 +1,16 @@
 """Core module for OpenAgent Eval."""
 
-from openagent_eval.core.engine import Engine
+from openagent_eval.core.engine import Engine, EvaluationReport
 from openagent_eval.core.executor import Executor
-from openagent_eval.core.pipeline import Pipeline
+from openagent_eval.core.pipeline import EvaluationResult, Pipeline, PipelineResult
 from openagent_eval.core.registry import Registry
 
-__all__ = ["Engine", "Executor", "Pipeline", "Registry"]
+__all__ = [
+    "Engine",
+    "EvaluationReport",
+    "EvaluationResult",
+    "Executor",
+    "Pipeline",
+    "PipelineResult",
+    "Registry",
+]

--- a/tests/unit/test_core/test_exports.py
+++ b/tests/unit/test_core/test_exports.py
@@ -1,16 +1,21 @@
 """Tests for the public import surface of ``openagent_eval.core``.
 
-Regression guard for #55: the core dataclasses (``EvaluationReport``,
-``EvaluationResult``, ``PipelineResult``) must be importable directly from the
-package, not only from their defining submodules.
+Regression guard for #55: every name in ``core.__all__`` must be importable
+directly from the package, not only from its defining submodule, and must be
+the exact same object as the one defined there (no accidental shadowing or
+copying).
 """
 
 from __future__ import annotations
 
 import openagent_eval.core as core
+from openagent_eval.core.engine import Engine as EngineEngine
 from openagent_eval.core.engine import EvaluationReport as EngineEvaluationReport
+from openagent_eval.core.executor import Executor as ExecutorExecutor
 from openagent_eval.core.pipeline import EvaluationResult as PipelineEvaluationResult
+from openagent_eval.core.pipeline import Pipeline as PipelinePipeline
 from openagent_eval.core.pipeline import PipelineResult as PipelinePipelineResult
+from openagent_eval.core.registry import Registry as RegistryRegistry
 
 
 def test_all_lists_the_full_public_surface() -> None:
@@ -32,14 +37,22 @@ def test_every_name_in_all_is_importable() -> None:
         assert hasattr(core, name), f"{name} listed in __all__ but not importable"
 
 
-def test_dataclasses_reexported_are_the_defining_objects() -> None:
-    """The re-exported dataclasses must be the same objects as their originals."""
+def test_reexported_names_are_the_defining_objects() -> None:
+    """Every re-exported name must be the same object as its original."""
     from openagent_eval.core import (
+        Engine,
         EvaluationReport,
         EvaluationResult,
+        Executor,
+        Pipeline,
         PipelineResult,
+        Registry,
     )
 
+    assert Engine is EngineEngine
     assert EvaluationReport is EngineEvaluationReport
     assert EvaluationResult is PipelineEvaluationResult
+    assert Executor is ExecutorExecutor
+    assert Pipeline is PipelinePipeline
     assert PipelineResult is PipelinePipelineResult
+    assert Registry is RegistryRegistry

--- a/tests/unit/test_core/test_exports.py
+++ b/tests/unit/test_core/test_exports.py
@@ -1,0 +1,45 @@
+"""Tests for the public import surface of ``openagent_eval.core``.
+
+Regression guard for #55: the core dataclasses (``EvaluationReport``,
+``EvaluationResult``, ``PipelineResult``) must be importable directly from the
+package, not only from their defining submodules.
+"""
+
+from __future__ import annotations
+
+import openagent_eval.core as core
+from openagent_eval.core.engine import EvaluationReport as EngineEvaluationReport
+from openagent_eval.core.pipeline import EvaluationResult as PipelineEvaluationResult
+from openagent_eval.core.pipeline import PipelineResult as PipelinePipelineResult
+
+
+def test_all_lists_the_full_public_surface() -> None:
+    """``__all__`` must enumerate exactly the intended public names."""
+    assert set(core.__all__) == {
+        "Engine",
+        "EvaluationReport",
+        "EvaluationResult",
+        "Executor",
+        "Pipeline",
+        "PipelineResult",
+        "Registry",
+    }
+
+
+def test_every_name_in_all_is_importable() -> None:
+    """Every name in ``__all__`` must actually be a package attribute."""
+    for name in core.__all__:
+        assert hasattr(core, name), f"{name} listed in __all__ but not importable"
+
+
+def test_dataclasses_reexported_are_the_defining_objects() -> None:
+    """The re-exported dataclasses must be the same objects as their originals."""
+    from openagent_eval.core import (
+        EvaluationReport,
+        EvaluationResult,
+        PipelineResult,
+    )
+
+    assert EvaluationReport is EngineEvaluationReport
+    assert EvaluationResult is PipelineEvaluationResult
+    assert PipelineResult is PipelinePipelineResult


### PR DESCRIPTION
Fixes #55

Adds the three missing re-exports to `openagent_eval/core/__init__.py` (`__all__` + isort-ordered imports), exactly as the issue specifies. The new import-surface test follows the repo's existing `set(module.__all__) == {...}` pattern (from `test_cli/test_main.py`) and asserts the re-exports are the same objects as the defining classes.

Gates: `uv run pytest tests/unit` — 937 passed, 4 skipped (+3 new).

Generated by Claude Fable 5 (brief, review), Claude Opus 4.8 (implementation)