### PR TITLE
fix: include reports subpackage in sdist — v0.4.8 (#233)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,4 +242,4 @@ config.groq.yaml
 config.*.yaml
 
 # Generated eval report artifacts
-reports/
+/reports/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [0.4.8] - 2026-07-24
+
+### Fixed
+
+- **Missing Reports Subpackage in sdist** — anchor `reports/` in `.gitignore` to root-only and add explicit sdist include for `openagent_eval/reports/`; 0.4.7 wheel/sdist shipped without the `reports` subpackage, making all CLI commands fail at import (#233)
+
+---
+
 ## [0.4.7] - 2026-07-24
 
 ### Fixed
@@ -445,7 +453,8 @@ This project follows [Semantic Versioning](https://semver.org/):
 
 ## Links
 
-[Unreleased]: https://github.com/openagenthq/openagent-eval/compare/v0.4.7...HEAD
+[Unreleased]: https://github.com/openagenthq/openagent-eval/compare/v0.4.8...HEAD
+[0.4.8]: https://github.com/openagenthq/openagent-eval/compare/v0.4.7...v0.4.8
 [0.4.7]: https://github.com/openagenthq/openagent-eval/compare/v0.4.6...v0.4.7
 [0.4.6]: https://github.com/openagenthq/openagent-eval/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/openagenthq/openagent-eval/compare/v0.4.4...v0.4.5

--- a/openagent_eval/__init__.py
+++ b/openagent_eval/__init__.py
@@ -1,4 +1,4 @@
 """OpenAgent Eval - Open-source CLI framework for evaluating RAG systems and AI Agents."""
 
-__version__ = "0.4.7"
-__author__ = "Himansh"
+__version__ = "0.4.8"
+__author__ = "Himanshu Kumar"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openagent-eval"
-version = "0.4.7"
+version = "0.4.8"
 description = "Open-source CLI framework for evaluating RAG systems and AI Agents"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -119,6 +119,7 @@ packages = ["openagent_eval"]
 [tool.hatch.build.targets.sdist]
 include = [
     "openagent_eval/",
+    "openagent_eval/reports/",
     "LICENSE",
     "README.md",
     "CHANGELOG.md",


### PR DESCRIPTION
## What's Changed

### 🐛 Bug Fixes
- **Missing Reports Subpackage in sdist** — anchor \eports/\ in \.gitignore\ to root-only (\/reports/\) so hatch sdist does not exclude \openagent_eval/reports/\. Also add explicit sdist include for belt-and-suspenders safety (#233)

### ⚙️ Internal
- **Packaging Fix** — add \.gitignore\ root-anchoring and explicit \pyproject.toml\ sdist include to prevent future packaging regressions

---

## Problem

The v0.4.7 wheel and sdist were missing the entire \openagent_eval.reports\ subpackage — 9 Python files + 1 HTML template. Every CLI command died at import:

\\\
ModuleNotFoundError: No module named 'openagent_eval.reports'
\\\

**Root cause:** \.gitignore\ had \eports/\ (unanchored), which matched \openagent_eval/reports/\ at any depth. Hatch uses git to determine sdist contents, so the entire subpackage was excluded.

## Fix

1. **\.gitignore\** — changed \eports/\ → \/reports/\ (root-only)
2. **\pyproject.toml\** — added explicit \openagent_eval/reports/\ to sdist include list

## Verification

- [x] \uv build\ — both wheel and sdist include all 9 reports files + template
- [x] Wheel: \openagent_eval/reports/*.py\ present
- [x] Sdist: \openagent_eval-0.4.8/openagent_eval/reports/*.py\ present

---

**Full Changelog**: https://github.com/openagenthq/openagent-eval/compare/v0.4.7...v0.4.8