### PR TITLE
feat(reports): add EvaluationReport type hints to report generators

### DIFF
--- a/openagent_eval/reports/__init__.py
+++ b/openagent_eval/reports/__init__.py
@@ -13,6 +13,7 @@ from openagent_eval.reports.base import (
     FailureInfo,
     ReportConfig,
     ReportGenerator,
+    ReportInput,
 )
 from openagent_eval.reports.comparison import ComparisonReport
 from openagent_eval.reports.html import HTMLReport
@@ -23,6 +24,7 @@ from openagent_eval.reports.terminal import TerminalReport
 __all__ = [
     "ReportGenerator",
     "ReportConfig",
+    "ReportInput",
     "FailureInfo",
     "ExperimentComparison",
     "TerminalReport",

--- a/openagent_eval/reports/base.py
+++ b/openagent_eval/reports/base.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from openagent_eval.core.engine import EvaluationReport
 from openagent_eval.core.pipeline import PipelineResult
 
 
@@ -67,6 +68,10 @@ class ExperimentComparison:
     metric_deltas: dict[str, float] = field(default_factory=dict)
 
 
+# Concrete generators accept EvaluationReport; ComparisonReport uses ExperimentComparison.
+ReportInput = EvaluationReport | ExperimentComparison
+
+
 class ReportGenerator(ABC):
     """Abstract base class for all report generators.
 
@@ -83,7 +88,7 @@ class ReportGenerator(ABC):
     """
 
     @abstractmethod
-    def generate(self, report: Any) -> str:
+    def generate(self, report: EvaluationReport) -> str:
         """Generate a report from evaluation results.
 
         Args:
@@ -95,7 +100,9 @@ class ReportGenerator(ABC):
         ...
 
     @abstractmethod
-    def generate_to_file(self, report: Any, output_path: Path | str) -> Path:
+    def generate_to_file(
+        self, report: EvaluationReport, output_path: Path | str
+    ) -> Path:
         """Generate a report and write it to a file.
 
         Args:

--- a/openagent_eval/reports/comparison.py
+++ b/openagent_eval/reports/comparison.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
 from openagent_eval.reports.base import ExperimentComparison, ReportGenerator
 
@@ -23,7 +22,7 @@ class ComparisonReport(ReportGenerator):
     - Winner determination
     """
 
-    def generate(self, report: Any) -> str:
+    def generate(self, report: ExperimentComparison) -> str:  # type: ignore[override]
         """Generate a comparison report string.
 
         Note: ``report`` should be an ExperimentComparison object.
@@ -163,7 +162,9 @@ class ComparisonReport(ReportGenerator):
 
         return "\n".join(lines)
 
-    def generate_to_file(self, report: Any, output_path: Path | str) -> Path:
+    def generate_to_file(  # type: ignore[override]
+        self, report: ExperimentComparison, output_path: Path | str
+    ) -> Path:
         """Generate comparison report and write to file.
 
         Args:

--- a/openagent_eval/reports/html.py
+++ b/openagent_eval/reports/html.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from openagent_eval.core.engine import EvaluationReport
 from openagent_eval.reports.base import ReportGenerator
 
 
@@ -81,7 +82,7 @@ class HTMLReport(ReportGenerator):
         template = env.from_string(template_str)
         return template.render(**context)
 
-    def generate(self, report: Any) -> str:
+    def generate(self, report: EvaluationReport) -> str:
         """Generate an HTML report string.
 
         Args:
@@ -138,7 +139,7 @@ class HTMLReport(ReportGenerator):
 
         return self._render_template(context)
 
-    def generate_to_file(self, report: Any, output_path: Path | str) -> Path:
+    def generate_to_file(self, report: EvaluationReport, output_path: Path | str) -> Path:
         """Generate HTML report and write to file.
 
         Args:

--- a/openagent_eval/reports/json_report.py
+++ b/openagent_eval/reports/json_report.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from openagent_eval.core.engine import EvaluationReport
 from openagent_eval.reports.base import ReportGenerator
 
 
@@ -36,7 +37,7 @@ class JSONReport(ReportGenerator):
         self.indent = indent
         self.sort_keys = sort_keys
 
-    def generate(self, report: Any) -> str:
+    def generate(self, report: EvaluationReport) -> str:
         """Generate a JSON report string.
 
         Args:
@@ -117,7 +118,7 @@ class JSONReport(ReportGenerator):
             ensure_ascii=False,
         )
 
-    def generate_to_file(self, report: Any, output_path: Path | str) -> Path:
+    def generate_to_file(self, report: EvaluationReport, output_path: Path | str) -> Path:
         """Generate JSON report and write to file.
 
         Args:
@@ -137,7 +138,7 @@ class JSONReport(ReportGenerator):
         path.write_text(content, encoding="utf-8")
         return path
 
-    def generate_compact(self, report: Any) -> str:
+    def generate_compact(self, report: EvaluationReport) -> str:
         """Generate a compact JSON report without indentation.
 
         Args:

--- a/openagent_eval/reports/manager.py
+++ b/openagent_eval/reports/manager.py
@@ -6,7 +6,7 @@ import json
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from openagent_eval.core.engine import EvaluationReport
 from openagent_eval.core.pipeline import EvaluationResult, PipelineResult
@@ -91,7 +91,7 @@ class ReportManager:
         path = output_dir / f"{report_id}.json"
         if not path.exists():
             raise FileNotFoundError(f"Report not found: {report_id}")
-        return json.loads(path.read_text(encoding="utf-8"))
+        return cast("dict[str, Any]", json.loads(path.read_text(encoding="utf-8")))
 
     def list_reports(self, output_dir: Path) -> list[dict[str, str]]:
         """List all reports in the output directory.

--- a/openagent_eval/reports/markdown.py
+++ b/openagent_eval/reports/markdown.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
+from openagent_eval.core.engine import EvaluationReport
 from openagent_eval.reports.base import ReportGenerator
 
 
@@ -25,7 +25,7 @@ class MarkdownReport(ReportGenerator):
     - Configuration details
     """
 
-    def generate(self, report: Any) -> str:
+    def generate(self, report: EvaluationReport) -> str:
         """Generate a Markdown report string.
 
         Args:
@@ -166,7 +166,7 @@ class MarkdownReport(ReportGenerator):
 
         return "\n".join(sections)
 
-    def generate_to_file(self, report: Any, output_path: Path | str) -> Path:
+    def generate_to_file(self, report: EvaluationReport, output_path: Path | str) -> Path:
         """Generate Markdown report and write to file.
 
         Args:

--- a/openagent_eval/reports/terminal.py
+++ b/openagent_eval/reports/terminal.py
@@ -7,12 +7,12 @@ results as formatted console output with tables, panels, and colors.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from openagent_eval.core.engine import EvaluationReport
 from openagent_eval.reports.base import ReportGenerator
 
 
@@ -34,7 +34,7 @@ class TerminalReport(ReportGenerator):
         """
         self.console = console or Console()
 
-    def generate(self, report: Any) -> str:
+    def generate(self, report: EvaluationReport) -> str:
         """Generate a terminal report string.
 
         Note: This returns the plain-text representation. For rich
@@ -97,7 +97,7 @@ class TerminalReport(ReportGenerator):
 
         return "\n".join(lines)
 
-    def generate_to_file(self, report: Any, output_path: Path | str) -> Path:
+    def generate_to_file(self, report: EvaluationReport, output_path: Path | str) -> Path:
         """Generate terminal report and write to file.
 
         Args:
@@ -117,7 +117,7 @@ class TerminalReport(ReportGenerator):
         path.write_text(content, encoding="utf-8")
         return path
 
-    def print_report(self, report: Any) -> None:
+    def print_report(self, report: EvaluationReport) -> None:
         """Print a rich-formatted report to the console.
 
         Args:


### PR DESCRIPTION
## Summary

Add proper type annotations to public report generator APIs, replacing untyped `report: Any` parameters with concrete types.

## Motivation

Issue #115 requests type hints on the reports module to improve IDE autocompletion and catch type-related bugs early under mypy strict mode.

## Changes

- Tighten `ReportGenerator` ABC signatures to use `EvaluationReport`
- Export `ReportInput` union alias (`EvaluationReport | ExperimentComparison`)
- Type `TerminalReport`, `MarkdownReport`, `HTMLReport`, and `JSONReport` with `EvaluationReport`
- Type `ComparisonReport` with `ExperimentComparison` (with override ignores for the ABC)
- Cast `load_report()` JSON deserialization for mypy `no-any-return` compliance

## Tests

```bash
python3 -m mypy openagent_eval/reports/
python3 -m pytest tests/unit/test_reports/ -q
```

- mypy: Success (8 source files)
- pytest: 101/101 passed

## Notes

- `ComparisonReport` intentionally narrows the input type to `ExperimentComparison`; runtime `isinstance` guard retained for the existing wrong-type test.
- No behavioral changes; annotations only.

Fixes #115