### PR TITLE
fix(corpus): make AuditReport.timestamp UTC-aware

### DIFF
--- a/openagent_eval/corpus/models.py
+++ b/openagent_eval/corpus/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
@@ -68,7 +68,7 @@ class AuditReport(BaseModel):
     issues: list[CorpusIssue] = Field(default_factory=list)
     health_score: float = Field(ge=0.0, le=1.0, default=1.0)
     checks_performed: list[str] = Field(default_factory=list)
-    timestamp: datetime = Field(default_factory=datetime.now)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
     summary: str = ""
     metadata: dict[str, Any] = Field(default_factory=dict)
 

--- a/tests/unit/test_corpus/test_models.py
+++ b/tests/unit/test_corpus/test_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC
 
 import pytest
 
@@ -71,6 +72,13 @@ class TestAuditReport:
         assert report.health_score == 1.0
         assert len(report.issues) == 0
         assert report.healthy is True
+
+    def test_default_timestamp_is_timezone_aware_utc(self):
+        """AuditReport timestamps should be UTC-aware for staleness comparisons."""
+        report = AuditReport(corpus_path="/test/corpus", total_documents=1)
+
+        assert report.timestamp.tzinfo is not None
+        assert report.timestamp.tzinfo == UTC
 
     def test_report_with_issues(self):
         """Test report with issues affects health score."""


### PR DESCRIPTION
## Summary

Make the default `AuditReport.timestamp` timezone-aware UTC instead of a naive local `datetime.now()`.

## Motivation

`StalenessDetector` and other corpus audit code use UTC-aware datetimes (`datetime.now(UTC)`). `AuditReport.timestamp` defaulted to naive `datetime.now()`, which is inconsistent and can raise `TypeError` when compared with aware datetimes.

Fixes #59

## Changes

- `openagent_eval/corpus/models.py`: default `timestamp` factory now uses `datetime.now(UTC)`
- `tests/unit/test_corpus/test_models.py`: regression test asserting default timestamp is UTC-aware

## Tests

- `pytest tests/unit/test_corpus/test_models.py -q` — 13 passed

## Notes

- composer-2.5 review: APPROVE
- Commit author: syf2211 <syf2211@users.noreply.github.com>