### PR TITLE
fix(corpus): limit contradiction detector LLM concurrency

### DIFF
--- a/openagent_eval/corpus/contradiction.py
+++ b/openagent_eval/corpus/contradiction.py
@@ -110,7 +110,7 @@ class ContradictionDetector(BaseCorpusAnalyzer):
             )
 
         # Compare pairs using LLM with bounded concurrency
-        semaphore = asyncio.Semaphore(5)
+        semaphore = asyncio.Semaphore(self.max_concurrency)
 
         async def bounded_compare(
             doc_a: CorpusDocument,

--- a/openagent_eval/corpus/contradiction.py
+++ b/openagent_eval/corpus/contradiction.py
@@ -58,6 +58,7 @@ class ContradictionDetector(BaseCorpusAnalyzer):
         llm_provider: Any | None = None,
         model: str | None = None,
         max_pairs: int = 50,
+        max_concurrency: int = 5,
     ) -> None:
         """Initialize the contradiction detector.
 
@@ -65,10 +66,12 @@ class ContradictionDetector(BaseCorpusAnalyzer):
             llm_provider: LLM provider instance with a generate() method.
             model: Model identifier (for display purposes).
             max_pairs: Maximum document pairs to compare.
+            max_concurrency: Maximum number of concurrent LLM requests.
         """
         self.llm_provider = llm_provider
         self.model = model
         self.max_pairs = max_pairs
+        self.max_concurrency = max_concurrency
 
     async def analyze(
         self,
@@ -106,9 +109,24 @@ class ContradictionDetector(BaseCorpusAnalyzer):
                 metadata={"requires_llm": True},
             )
 
-        # Compare pairs using LLM
-        tasks = [self._compare_pair(doc_a, doc_b) for doc_a, doc_b in pairs[:self.max_pairs]]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
+        # Compare pairs using LLM with bounded concurrency
+        semaphore = asyncio.Semaphore(5)
+
+        async def bounded_compare(
+            doc_a: CorpusDocument,
+            doc_b: CorpusDocument,
+        ) -> CorpusIssue | None:
+            async with semaphore:
+                return await self._compare_pair(doc_a, doc_b)
+
+        tasks = [
+            bounded_compare(doc_a, doc_b) for doc_a, doc_b in pairs[: self.max_pairs]
+        ]
+
+        results = await asyncio.gather(
+            *tasks,
+            return_exceptions=True,
+        )
 
         for result in results:
             if isinstance(result, CorpusIssue):
@@ -155,9 +173,7 @@ class ContradictionDetector(BaseCorpusAnalyzer):
             for doc_b in documents[i + 1 :]:
                 words_b = set(doc_b.content.lower().split())
                 # Check for shared significant words (length > 4)
-                shared = {
-                    w for w in words_a & words_b if len(w) > 4
-                }
+                shared = {w for w in words_a & words_b if len(w) > 4}
                 if len(shared) >= 3:
                     pairs.append((doc_a, doc_b))
 
@@ -189,7 +205,11 @@ class ContradictionDetector(BaseCorpusAnalyzer):
             response = await self.llm_provider.generate(prompt)
             result = self._parse_response(response)
 
-            if result and result.get("contradicts") and result.get("confidence", 0) > 0.7:
+            if (
+                result
+                and result.get("contradicts")
+                and result.get("confidence", 0) > 0.7
+            ):
                 severity = (
                     IssueSeverity.HIGH
                     if result.get("confidence", 0) > 0.9
@@ -199,7 +219,9 @@ class ContradictionDetector(BaseCorpusAnalyzer):
                     issue_type=IssueType.CONTRADICTION,
                     severity=severity,
                     title=f"Contradiction on '{result.get('topic', 'shared topic')}'",
-                    description=result.get("explanation", "Documents present conflicting information"),
+                    description=result.get(
+                        "explanation", "Documents present conflicting information"
+                    ),
                     document_ids=[doc_a.doc_id, doc_b.doc_id],
                     metadata={
                         "confidence": result.get("confidence", 0),
@@ -228,7 +250,9 @@ class ContradictionDetector(BaseCorpusAnalyzer):
             start = response.find("{")
             end = response.rfind("}") + 1
             if start != -1 and end > start:
-                return json.loads(response[start:end])
+                parsed = json.loads(response[start:end])
+                if isinstance(parsed, dict):
+                    return parsed
         except (json.JSONDecodeError, ValueError):
             pass
         return None

--- a/tests/unit/test_corpus/test_contradiction.py
+++ b/tests/unit/test_corpus/test_contradiction.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from openagent_eval.corpus.contradiction import ContradictionDetector
@@ -18,6 +20,32 @@ class MockLLMProvider:
     async def generate(self, prompt: str) -> str:
         self.calls.append(prompt)
         return self.response
+
+
+class ConcurrencyTrackingLLMProvider:
+    """Tracks maximum concurrent LLM requests."""
+
+    def __init__(self) -> None:
+        self.active_calls = 0
+        self.max_active_calls = 0
+
+    async def generate(self, prompt: str) -> str:
+        self.active_calls += 1
+        self.max_active_calls = max(
+            self.max_active_calls,
+            self.active_calls,
+        )
+
+        await asyncio.sleep(0.01)
+
+        self.active_calls -= 1
+
+        return (
+            '{"contradicts": false, '
+            '"confidence": 0.1, '
+            '"topic": "test", '
+            '"explanation": "No contradiction"}'
+        )
 
 
 class TestContradictionDetector:
@@ -150,7 +178,10 @@ class TestContradictionDetector:
         ]
 
         report = await detector.analyze(docs)
-        assert "contradiction" in report.summary.lower() or "no contradictions" in report.summary.lower()
+        assert (
+            "contradiction" in report.summary.lower()
+            or "no contradictions" in report.summary.lower()
+        )
 
     @pytest.mark.asyncio
     async def test_health_score_computation(self, detector_no_llm):
@@ -166,3 +197,29 @@ class TestContradictionDetector:
         # Some issues = reduced score
         score = detector_no_llm._compute_health_score(10, 5)
         assert score < 1.0
+
+    @pytest.mark.asyncio
+    async def test_limits_concurrent_llm_requests(self):
+        """Ensure contradiction detection limits concurrent LLM requests."""
+
+        llm = ConcurrencyTrackingLLMProvider()
+        detector = ContradictionDetector(
+            llm_provider=llm,
+            max_pairs=20,
+        )
+
+        docs = [
+            CorpusDocument(
+                doc_id=f"doc{i}.txt",
+                content=(
+                    "Python programming language supports machine learning "
+                    f"applications and data science version {i}"
+                ),
+            )
+            for i in range(8)
+        ]
+
+        await detector.analyze(docs)
+
+        assert llm.max_active_calls <= 5
+        assert llm.max_active_calls > 1

--- a/tests/unit/test_corpus/test_contradiction.py
+++ b/tests/unit/test_corpus/test_contradiction.py
@@ -222,4 +222,4 @@ class TestContradictionDetector:
         await detector.analyze(docs)
 
         assert llm.max_active_calls <= 5
-        assert llm.max_active_calls > 1
+        assert 1 < llm.max_active_calls <= detector.max_concurrency


### PR DESCRIPTION
## Summary

Fixes #58.

Adds bounded concurrency to `ContradictionDetector` to prevent all document-pair LLM requests from being executed simultaneously.

Previously, the detector created up to `max_pairs` LLM calls at once using `asyncio.gather()`. With the default `max_pairs=50`, this could result in up to 50 concurrent requests, increasing the likelihood of provider rate limits and excessive resource usage.

## Changes

- Added configurable `max_concurrency` parameter with a default of `5`
- Added an `asyncio.Semaphore` to limit simultaneous LLM requests
- Added a bounded comparison helper for document-pair processing
- Preserved the existing `max_pairs` behavior
- Added regression coverage verifying that concurrent LLM requests never exceed the configured limit
- Improved LLM response parsing by validating that parsed JSON is an object before returning it

## Testing

Verified with:

- `uv run pytest tests/unit/test_corpus/test_contradiction.py -v`
  - 9 tests passed
- `uv run ruff check openagent_eval/corpus/contradiction.py tests/unit/test_corpus/test_contradiction.py`
  - All checks passed
- `uv run mypy openagent_eval/corpus/contradiction.py`
  - Success: no issues found

## Notes

This change limits concurrency but does not introduce retry/backoff behavior. Retry handling can be added separately if desired.