### PR TITLE
fix(executor): async run_in_thread, cancel siblings on timeout, lazy thread pool

### DIFF
--- a/openagent_eval/core/executor.py
+++ b/openagent_eval/core/executor.py
@@ -26,7 +26,7 @@ class Executor:
         self.max_workers = max_workers
         self.timeout = timeout
         self._semaphore = asyncio.Semaphore(max_workers)
-        self._thread_pool = ThreadPoolExecutor(max_workers=max_workers)
+        self._thread_pool: ThreadPoolExecutor | None = None
 
     async def execute_parallel(
         self,
@@ -80,7 +80,8 @@ class Executor:
             List of results in the same order as ``coroutines``.
 
         Raises:
-            MetricExecutionError: If a coroutine times out.
+            MetricExecutionError: If a coroutine times out. The first
+                failure cancels the remaining coroutines.
         """
         async def _run(coro: Any) -> Any:
             async with self._semaphore:
@@ -92,7 +93,16 @@ class Executor:
                         details={"timeout": self.timeout},
                     ) from None
 
-        return await asyncio.gather(*[_run(c) for c in coroutines])
+        try:
+            async with asyncio.TaskGroup() as tg:
+                tasks = [tg.create_task(_run(c)) for c in coroutines]
+        except* Exception as eg:
+            # TaskGroup cancels the remaining tasks and bundles the
+            # failures; re-raise the first one to preserve the public
+            # error contract (e.g. MetricExecutionError on timeout).
+            raise eg.exceptions[0] from None
+
+        return [t.result() for t in tasks]
 
     async def execute_sequential(
         self,
@@ -133,7 +143,7 @@ class Executor:
                 ) from e
         return results
 
-    def run_in_thread(
+    async def run_in_thread(
         self,
         func: Callable[..., Any],
         *args: Any,
@@ -147,17 +157,18 @@ class Executor:
             **kwargs: Keyword arguments to pass to the function.
 
         Returns:
-            An awaitable resolving to the result of the function.
+            The result of the function.
         """
-        loop = asyncio.get_event_loop()
-        if not loop.is_running():
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-        return loop.run_in_executor(
+        if self._thread_pool is None:
+            self._thread_pool = ThreadPoolExecutor(max_workers=self.max_workers)
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
             self._thread_pool,
             lambda: func(*args, **kwargs),
         )
 
     def shutdown(self) -> None:
         """Shutdown the executor and clean up resources."""
-        self._thread_pool.shutdown(wait=True)
+        if self._thread_pool is not None:
+            self._thread_pool.shutdown(wait=True)
+            self._thread_pool = None

--- a/tests/unit/test_core/test_executor.py
+++ b/tests/unit/test_core/test_executor.py
@@ -1,0 +1,137 @@
+"""Regression tests for the Executor (#49, #50, #54)."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any
+
+import pytest
+
+from openagent_eval.core.executor import Executor
+from openagent_eval.exceptions import MetricExecutionError
+
+
+class TestRunInThread:
+    """Regression tests for issue #49 (event loop handling)."""
+
+    @pytest.mark.asyncio
+    async def test_run_in_thread_from_running_loop(self) -> None:
+        """Test awaiting run_in_thread from a running event loop."""
+        executor = Executor()
+        try:
+            result = await executor.run_in_thread(lambda x: x + 1, 41)
+            assert result == 42
+        finally:
+            executor.shutdown()
+
+    def test_run_in_thread_without_running_loop(self) -> None:
+        """Test run_in_thread from a thread with no event loop set.
+
+        The old implementation called asyncio.get_event_loop(), which
+        raises RuntimeError in a thread without a current loop (always
+        on Python 3.12+), and leaked the loops it created. The fixed
+        coroutine must run cleanly under asyncio.run() and leave no
+        event loop set in the calling thread.
+        """
+        executor = Executor()
+        outcome: dict[str, Any] = {}
+
+        def target() -> None:
+            try:
+                outcome["result"] = asyncio.run(
+                    executor.run_in_thread(lambda x: x * 2, 21),
+                )
+            except Exception as e:
+                outcome["error"] = e
+            try:
+                asyncio.get_event_loop()
+            except RuntimeError:
+                outcome["leftover_loop"] = False
+            else:
+                outcome["leftover_loop"] = True
+
+        thread = threading.Thread(target=target)
+        thread.start()
+        thread.join()
+        executor.shutdown()
+
+        assert "error" not in outcome
+        assert outcome["result"] == 42
+        assert outcome["leftover_loop"] is False
+
+
+class TestGatherCancellation:
+    """Regression tests for issue #50 (sibling cancellation on timeout)."""
+
+    @pytest.mark.asyncio
+    async def test_gather_cancels_siblings_on_timeout(self) -> None:
+        """Test that a timed-out task cancels the remaining coroutines.
+
+        With max_workers=1 the sibling is still queued on the semaphore
+        when the first task times out, so its own per-task timeout has
+        not started: if gather() leaves it running (old behaviour) it
+        runs to completion once the semaphore is released. The sibling
+        must instead be cancelled before it can complete.
+        """
+        executor = Executor(max_workers=1, timeout=0.05)
+        sibling_completed = False
+
+        async def slow() -> None:
+            await asyncio.sleep(10)
+
+        async def sibling() -> str:
+            nonlocal sibling_completed
+            await asyncio.sleep(0.01)
+            sibling_completed = True
+            return "done"
+
+        with pytest.raises(MetricExecutionError) as exc_info:
+            await executor.gather([slow(), sibling()])
+
+        assert exc_info.value.message == "Task timed out after 0.05s"
+        assert exc_info.value.details == {"timeout": 0.05}
+
+        # Give any orphaned sibling task a chance to run to completion.
+        await asyncio.sleep(0.2)
+        assert not sibling_completed
+        executor.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_gather_returns_results(self) -> None:
+        """Test that gather still returns results in order on success."""
+        executor = Executor(max_workers=2, timeout=5.0)
+
+        async def make(value: int) -> int:
+            await asyncio.sleep(0)
+            return value * 2
+
+        results = await executor.gather([make(1), make(2), make(3)])
+        assert results == [2, 4, 6]
+        executor.shutdown()
+
+
+class TestLazyThreadPool:
+    """Regression tests for issue #54 (lazy thread pool allocation)."""
+
+    def test_no_thread_pool_on_init(self) -> None:
+        """Test that constructing an Executor allocates no thread pool."""
+        executor = Executor()
+        assert executor._thread_pool is None
+
+    def test_shutdown_without_use_does_not_raise(self) -> None:
+        """Test that shutdown() on a never-used executor does not raise."""
+        executor = Executor()
+        executor.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_thread_pool_created_on_first_use(self) -> None:
+        """Test that the thread pool is created lazily by run_in_thread."""
+        executor = Executor()
+        try:
+            assert executor._thread_pool is None
+            await executor.run_in_thread(lambda: 1)
+            assert executor._thread_pool is not None
+        finally:
+            executor.shutdown()
+        assert executor._thread_pool is None


### PR DESCRIPTION
## Description

Three interlocking defects in `openagent_eval/core/executor.py`:

- `run_in_thread` called `asyncio.get_event_loop()` and created a new loop when none was running, never closing it. On Python 3.12+ that call raises `RuntimeError` outright, so the method could not work at all from a thread without a loop. It is now `async def` and uses `asyncio.get_running_loop()`. Callers already awaited the result, so the call contract is unchanged.
- `gather()` used `asyncio.gather` with the default `return_exceptions=False`, so when one coroutine timed out the siblings kept running with their results discarded. It now uses `asyncio.TaskGroup`, which cancels the remaining tasks, and re-raises the first exception so the public error contract is preserved — a timeout still surfaces as `MetricExecutionError` with the same message and `details={"timeout": self.timeout}`.
- The `ThreadPoolExecutor` was constructed eagerly in `__init__` but only ever used by `run_in_thread`. It is now created on first use, and `shutdown()` handles the never-used case.

No public API is removed. `execute_parallel` and `execute_sequential` are untouched — see Additional Notes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update
- [ ] CI/CD update

## Related Issues

Closes #49
Closes #50
Closes #54

## How Has This Been Tested?

Seven new tests in `tests/unit/test_core/test_executor.py`, each written so it fails without the fix. Verified by reverting `executor.py` alone to `main` and keeping the tests: **4 failed, 3 passed**. With the fix restored: **7 passed**.

- `test_run_in_thread_without_running_loop` — on `main` this fails with `RuntimeError: There is no current event loop in thread 'Thread-3 (target)'`, which is exactly the 3.12+ crash #49 predicts.
- `test_gather_cancels_siblings_on_timeout` — uses `max_workers=1` so the sibling is still queued on the semaphore when the first task times out. On `main` the orphaned sibling acquires the released semaphore and runs to completion; the test asserts it does not.
- `test_no_thread_pool_on_init` and `test_thread_pool_created_on_first_use` — both fail on `main`, where the pool exists from construction.

Worth flagging: the first version of the cancellation test passed against `main` as well, because the sibling outlived the shared `wait_for` deadline and was cancelled by its own timeout rather than by the fix. It proved nothing and was redesigned to the semaphore-queued form above. The failure counts quoted here are from the final version.

- [x] Unit tests pass (`uv run pytest`) — 980 passed, 4 skipped (API-key and chromadb skips) on `tests/unit`; 54 passed on `tests/integration`; full run with coverage 1034 passed, `--cov-fail-under=75` satisfied.
- [ ] Linter passes (`uv run ruff check .`) — exits 1 with 229 pre-existing findings across the repo. Six fall in the files this PR touches, and **all six are identical on `main`** (checked by running ruff against `git show upstream/main:openagent_eval/core/executor.py`). This change introduces none. Leaving the box unticked because the command does not pass, not because the change regressed it.
- [ ] Type checker passes (`uv run mypy openagent_eval/`) — see Additional Notes; the CI invocation of this check is currently inoperative.
- [x] Manual testing performed

Also ran `uvx --from build python -m build` and `uvx --from twine twine check dist/*` — both pass.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — no user-facing behaviour or documented API changed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**#52 is deliberately not addressed.** It asks for `execute_parallel` and `execute_sequential` to be deleted as dead code, and #54 suggests removing `run_in_thread` and the pool. Since this is a published package, removing public methods is a breaking change and your call rather than ours — so this PR fixes the defects without removing anything. `run_in_thread` does remain uncalled within the codebase, as #54 observes. If you want the removals, they are a clean follow-up.

**A correction to #54's premise.** It states that constructing the executor allocates four idle OS threads. CPython's `ThreadPoolExecutor` spawns workers lazily on first `submit`, so construction allocates the pool object but no threads. The lazy-init fix is still worth having and is applied, but the "4 idle threads" symptom does not reproduce — which is also why there is no thread-count test here, since it would pass either way.

**Consistency note.** `execute_parallel` and `execute_sequential` still use plain `asyncio.gather` and sequential `wait_for`, so they keep the old no-cancellation-on-failure behaviour. Left alone as part of the #52 scope above; if you would like cancellation there too, that pairs naturally with the #52 decision.

**Bug discovered while running your CI commands:** #250 — CI type-check step targets a non-existent src/ directory, so mypy has never run on the package. `ci.yml:54` runs `uv run mypy src --ignore-missing-imports || true`; there is no `src/`, mypy exits 2 with `Cannot read file 'src'`, and `|| true` hides it. Notably this template's own checklist has the correct path (`uv run mypy openagent_eval/`), so the workflow is the one out of step.

Generated by Claude Opus 5 (brief, review), Kimi K3 (implementation)
