### PR TITLE
fix(config): legacy migration silently overwrites, drops, and duplicates config

### DIFF
--- a/openagent_eval/config/loader.py
+++ b/openagent_eval/config/loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import yaml
@@ -9,6 +10,36 @@ from pydantic import ValidationError as PydanticValidationError
 
 from openagent_eval.config.models import Config
 from openagent_eval.exceptions import ConfigurationError
+
+logger = logging.getLogger(__name__)
+
+# Legacy metric name translation map.
+_LEGACY_METRIC_MAP: dict[str, str] = {
+    "precision": "context_precision",
+    "recall": "context_recall",
+    "mrr": "mrr",
+    "ndcg": "ndcg",
+    "hit_rate": "hit_rate",
+    "faithfulness": "faithfulness",
+    "relevancy": "answer_relevancy",
+    "hallucination": "hallucination",
+    "similarity": "semantic_similarity",
+    "latency": "latency",
+    "tokens": "token_count",
+}
+
+# Metric classification categories for legacy flat metrics lists.
+_RETRIEVAL_METRICS = frozenset({
+    "context_precision", "context_recall", "recall_at_k",
+    "precision_at_k", "hit_rate", "mrr", "ndcg",
+})
+_GENERATION_METRICS = frozenset({
+    "faithfulness", "answer_relevancy", "hallucination",
+    "semantic_similarity", "exact_match", "f1_score",
+    "bleu", "rouge", "bertscore",
+})
+_PERFORMANCE_METRICS = frozenset({"latency"})
+_COST_METRICS = frozenset({"token_count"})
 
 _FIELD_FORMAT_HINTS = {
     "llm.provider": (
@@ -102,38 +133,16 @@ def load_config(config_path: str | Path) -> Config:
 
         # Handle legacy 'metrics' field (flat list of strings) and translate
         # legacy metric names to the canonical registry names.
-        _LEGACY_METRIC_MAP = {
-            "precision": "context_precision",
-            "recall": "context_recall",
-            "mrr": "mrr",
-            "ndcg": "ndcg",
-            "hit_rate": "hit_rate",
-            "faithfulness": "faithfulness",
-            "relevancy": "answer_relevancy",
-            "hallucination": "hallucination",
-            "similarity": "semantic_similarity",
-            "latency": "latency",
-            "tokens": "token_count",
-        }
         if isinstance(raw_config.get("metrics"), list):
             metrics_list = raw_config.pop("metrics")
-            normalised = [
+            normalised = list(dict.fromkeys(
                 _LEGACY_METRIC_MAP.get(m, m) for m in metrics_list
-            ]
+            ))
             raw_config["metrics"] = {
-                "retrieval": [
-                    m for m in normalised
-                    if m in ("context_precision", "context_recall", "recall_at_k",
-                             "precision_at_k", "hit_rate", "mrr", "ndcg")
-                ],
-                "generation": [
-                    m for m in normalised
-                    if m in ("faithfulness", "answer_relevancy", "hallucination",
-                             "semantic_similarity", "exact_match", "f1_score",
-                             "bleu", "rouge", "bertscore")
-                ],
-                "performance": [m for m in normalised if m in ("latency",)],
-                "cost": [m for m in normalised if m in ("token_count",)],
+                "retrieval": [m for m in normalised if m in _RETRIEVAL_METRICS],
+                "generation": [m for m in normalised if m in _GENERATION_METRICS],
+                "performance": [m for m in normalised if m in _PERFORMANCE_METRICS],
+                "cost": [m for m in normalised if m in _COST_METRICS],
             }
 
             # Surface metrics that were silently dropped (unknown name or typo)
@@ -154,19 +163,26 @@ def load_config(config_path: str | Path) -> Config:
                 )
 
         # Handle legacy 'retrieval' block (provider/collection_name) -> 'retriever'.
-        if "retrieval" in raw_config and "retriever" not in raw_config:
-            retrieval = raw_config.pop("retrieval") or {}
-            provider = retrieval.get("provider") or "chroma"
-            settings = {}
-            if retrieval.get("collection_name"):
-                settings["collection_name"] = retrieval["collection_name"]
-            settings.update(retrieval.get("settings", {}))
-            raw_config["retriever"] = {"provider": provider, "settings": settings}
+        retrieval = raw_config.pop("retrieval", None)
+        if retrieval is not None:
+            if "retriever" in raw_config:
+                logger.warning(
+                    "Both 'retrieval' (legacy) and 'retriever' found in config. "
+                    "Using 'retriever', ignoring 'retrieval'."
+                )
+            else:
+                provider = retrieval.get("provider") or "chroma"
+                settings = {}
+                if retrieval.get("collection_name"):
+                    settings["collection_name"] = retrieval["collection_name"]
+                settings.update(retrieval.get("settings", {}))
+                raw_config["retriever"] = {"provider": provider, "settings": settings}
 
         # Handle legacy 'output' field (string format)
         if isinstance(raw_config.get("output"), str):
             output_format = raw_config.pop("output")
-            raw_config.setdefault("report", {})["output"] = output_format
+            report_block = raw_config.setdefault("report", {})
+            report_block.setdefault("output", output_format)
 
         config = Config(**raw_config)
         return config

--- a/tests/unit/test_config/test_models.py
+++ b/tests/unit/test_config/test_models.py
@@ -167,6 +167,79 @@ class TestConfigLoader:
 
         assert "totally_fake_metric" in caplog.text
 
+    # --- Issue #43 regression test ---
+    def test_load_config_legacy_output_does_not_overwrite_report_output(
+        self, tmp_path: Path
+    ) -> None:
+        """Legacy top-level 'output' must not clobber an explicit report.output."""
+        config_dict = {
+            "dataset": {"path": "data.json"},
+            "llm": {"provider": "openai", "model": "gpt-4o"},
+            "report": {"output": "html"},
+            "output": "terminal",
+        }
+        config_path = tmp_path / "legacy_output.yaml"
+        config_path.write_text(yaml.dump(config_dict), encoding="utf-8")
+
+        config = load_config(config_path)
+        assert config.report.output == OutputFormat.HTML
+
+    # --- Issue #44 regression test ---
+    def test_load_config_retrieval_and_retriever_prefers_retriever(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """When both legacy 'retrieval' and modern 'retriever' exist, retriever
+        wins, retrieval is discarded, and a warning is emitted."""
+        import logging
+
+        config_dict = {
+            "dataset": {"path": "data.json"},
+            "llm": {"provider": "openai", "model": "gpt-4o"},
+            "retrieval": {
+                "provider": "pinecone",
+                "collection_name": "legacy_docs",
+            },
+            "retriever": {"provider": "chroma", "settings": {"collection": "docs"}},
+        }
+        config_path = tmp_path / "both_retrievers.yaml"
+        config_path.write_text(yaml.dump(config_dict), encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING, logger="openagent_eval.config.loader"):
+            config = load_config(config_path)
+
+        assert config.retriever.provider == "chroma"
+        assert config.retriever.settings == {"collection": "docs"}
+        assert "retrieval" not in config.model_dump()
+        assert "Using 'retriever', ignoring 'retrieval'" in caplog.text
+
+    # --- Issue #45 regression test ---
+    def test_load_config_legacy_metrics_deduplicates_aliases(
+        self, tmp_path: Path
+    ) -> None:
+        """Legacy flat metrics list must not contain duplicates after alias
+        normalisation."""
+        config_dict = {
+            "dataset": {"path": "data.json"},
+            "llm": {"provider": "openai", "model": "gpt-4o"},
+            "metrics": ["tokens", "token_count"],
+        }
+        config_path = tmp_path / "duplicate_metrics.yaml"
+        config_path.write_text(yaml.dump(config_dict), encoding="utf-8")
+
+        config = load_config(config_path)
+        assert config.metrics.cost == ["token_count"]
+
+    # --- Issue #48 regression test ---
+    def test_loader_constants_are_module_level(self) -> None:
+        """Legacy metric constants must be defined at module level."""
+        from openagent_eval.config import loader
+
+        assert loader._LEGACY_METRIC_MAP["tokens"] == "token_count"
+        assert "token_count" in loader._COST_METRICS
+        assert "latency" in loader._PERFORMANCE_METRICS
+        assert "context_precision" in loader._RETRIEVAL_METRICS
+        assert "faithfulness" in loader._GENERATION_METRICS
+
 
 class TestCorpusConfigIntegration:
     """Issue #121: the corpus: section is part of the main Config."""


### PR DESCRIPTION
## Description

Four defects in `openagent_eval/config/loader.py`'s legacy-config migration. Three of them silently corrupt or discard user configuration; the fourth is a constants hoist.

- **#43** — `raw_config.setdefault("report", {})["output"] = output_format` unconditionally overwrites an explicit `report.output` with the legacy top-level `output`. Now uses `setdefault` on the nested key, so an explicit value wins.
- **#44** — the legacy `retrieval` block was only popped when `retriever` was absent, so a config carrying both left `retrieval` in place to be silently ignored by Pydantic as an extra field. It is now popped unconditionally, and when both are present a warning names which one is being used.
- **#45** — `tokens` and `token_count` both normalise to `token_count`, so a config naming both produced a duplicate and computed the metric twice. Deduplicated after normalisation, order preserved.
- **#48** — `_LEGACY_METRIC_MAP` and the metric-classification groups were rebuilt inside `load_config()` on every call. Hoisted to module level, with the classification groups as `frozenset`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update
- [ ] CI/CD update

## Related Issues

Closes #43
Closes #44
Closes #45
Closes #48

## How Has This Been Tested?

Four regression tests added to `tests/unit/test_config/test_models.py`, one per issue, each written so it fails without its fix. Verified by reverting `loader.py` alone to `main` and keeping the tests: **all four fail**. With the fix restored: **all four pass**.

- #43 — a config with both legacy `output` and an explicit `report.output`; asserts the explicit value survives.
- #44 — a config with both `retrieval` and `retriever`; asserts `retriever` wins, `retrieval` does not leak through, and the warning is emitted.
- #45 — a legacy flat `metrics` list naming both `tokens` and `token_count`; asserts no duplicate.
- #48 — asserts the constants are module-level attributes.

- [x] Unit tests pass (`uv run pytest`) — 977 passed, 4 skipped on `tests/unit`; 54 passed on `tests/integration`; full run with coverage at 79.65% against the 75% floor.
- [ ] Linter passes (`uv run ruff check .`) — exits 1 on 228 pre-existing findings repo-wide. On the two files touched here the branch has **fewer** findings than `main`: base 3 (`N806` in `loader.py`, plus `TC003`/`B017` in the test file), branch 2 (the two pre-existing test-file ones). Hoisting `_LEGACY_METRIC_MAP` out of the function clears the `N806`. Unticked because the repo-wide command does not pass, not because this change regressed it.
- [ ] Type checker passes (`uv run mypy openagent_eval/`) — see Additional Notes.
- [x] Manual testing performed

`uvx --from build python -m build` and `uvx --from twine twine check dist/*` both pass.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — no documented behaviour changed; these are silent-corruption fixes in a migration path
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**On #44's warning.** The issue's suggested fix used an inline `import logging` inside the function. This uses a module-level `logging.getLogger(__name__)` instead, matching the rest of the package. Worth noting there is an existing dropped-metrics warning at `loader.py:158-162` still using the inline pattern, now inconsistent with the new module-level logger — left alone to keep this diff to the four issues, but easy to fold in if you would rather they match.

**These are behaviour changes, deliberately.** A config carrying both a legacy and a modern key previously resolved one way and now resolves the other — that is the point of #43 and #44. Anyone relying on the old precedence would see a change, though relying on it seems unlikely given neither was documented and neither warned.

**Bug discovered while running your CI commands:** #250 — CI type-check step targets a non-existent src/ directory, so mypy has never run on the package. Independently hit again during this work. It is why the type-checker box above is unticked: the command in `ci.yml` cannot run, while this PR template's own checklist already names the correct path.

Generated by Claude Opus 5 (brief, review), Kimi K2.7 Code (implementation)
