### PR TITLE
fix(cicd): defer pytest import so oaeval works on a clean install

### DIFF
--- a/openagent_eval/cicd/plugin.py
+++ b/openagent_eval/cicd/plugin.py
@@ -24,11 +24,10 @@ Usage via pytest plugin:
 from __future__ import annotations
 
 import asyncio
+import sys
 import time
 from pathlib import Path
 from typing import Any, Generator
-
-import pytest
 
 from openagent_eval.cicd.models import CICDConfig, EvaluationGate, ThresholdConfig
 from openagent_eval.cicd.thresholds import EvaluationResult, ThresholdEvaluator
@@ -89,6 +88,8 @@ def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
     """Modify collected items to add OpenAgent Eval markers."""
+    import pytest
+
     for item in items:
         if "oaeval" in item.keywords:
             item.add_marker(pytest.mark.oaeval)
@@ -263,13 +264,20 @@ def pytest_runtest_makereport(
         report.oaeval_result = item._oaeval_result  # type: ignore[attr-defined]
 
 
-@pytest.hookimpl(tryfirst=True)
 def pytest_runtest_setup(item: pytest.Item) -> None:
     """Setup hook for OpenAgent Eval tests."""
     # Check if this is an oaeval test
     if "oaeval" in item.keywords:
         # Mark as oaeval test
         item._is_oaeval_test = True  # type: ignore[attr-defined]
+
+
+# Apply pytest hook decorator only when pytest is available.  This keeps the
+# module importable on clean installs that do not include pytest.
+if sys.modules.get("pytest") is not None:
+    import pytest
+
+    pytest_runtest_setup = pytest.hookimpl(tryfirst=True)(pytest_runtest_setup)
 
 
 def pytest_sessionfinish(

--- a/tests/unit/test_cicd/test_no_pytest_import.py
+++ b/tests/unit/test_cicd/test_no_pytest_import.py
@@ -1,0 +1,48 @@
+"""Regression test for issue #227.
+
+The CLI must be importable and runnable on a clean install that does not
+include pytest.  We verify this in-process by blocking the ``pytest`` name
+before importing the modules.
+"""
+
+import subprocess
+import sys
+
+
+def test_cicd_and_cli_import_without_pytest() -> None:
+    """Plugin and CLI entry point import cleanly when pytest is unavailable."""
+    code = (
+        "import sys\n"
+        "sys.modules['pytest'] = None\n"
+        "from openagent_eval.cicd import OAEvalPlugin\n"
+        "from openagent_eval.cli.main import app\n"
+        "print('import-ok')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "import-ok" in result.stdout
+
+
+def test_oaeval_help_runs_without_pytest() -> None:
+    """``oaeval --help`` works when pytest is unavailable."""
+    code = (
+        "import sys\n"
+        "sys.modules['pytest'] = None\n"
+        "from typer.testing import CliRunner\n"
+        "from openagent_eval.cli.main import app\n"
+        "runner = CliRunner()\n"
+        "result = runner.invoke(app, ['--help'])\n"
+        "print(result.output)\n"
+        "assert result.exit_code == 0, result.exception\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Usage:" in result.stdout


### PR DESCRIPTION
## Description

`oaeval` dies on any clean install because the CLI import chain reaches a module-level `import pytest`, and pytest is a dev dependency rather than a runtime one.

The chain, traced on current `main`:

```
pyproject.toml:95                        oaeval = "openagent_eval.cli.main:app"
openagent_eval/cli/main.py:23            from openagent_eval.cli.commands.test import test_command
openagent_eval/cli/commands/test.py:13   from openagent_eval.cicd.plugin import OAEvalPlugin
openagent_eval/cicd/__init__.py:14       from openagent_eval.cicd.plugin import OAEvalPlugin
openagent_eval/cicd/plugin.py:31         import pytest          # module scope
```

In a virtualenv carrying the runtime dependencies but not pytest, `oaeval --help` raises `ModuleNotFoundError: No module named 'pytest'` before printing anything. The import is now deferred into the plugin entrypoints that actually run under pytest, so the module imports cleanly without it.

This still reproduces at 0.4.8, not only at the 0.4.6 the issue was reported against — the post-fix run below reports `openagent-eval 0.4.8`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update
- [ ] CI/CD update

## Related Issues

Closes #227

## How Has This Been Tested?

Reproduced first, then fixed. In a virtualenv with the runtime dependencies and no pytest:

```
$ /tmp/oae-227-venv/bin/oaeval --help
Traceback (most recent call last):
  File "/tmp/oae-227-venv/bin/oaeval", line 3, in <module>
    from openagent_eval.cli.main import app
  ...
  File ".../openagent_eval/cicd/plugin.py", line 31, in <module>
    import pytest
ModuleNotFoundError: No module named 'pytest'
```

After the change, same virtualenv:

```
$ /tmp/oae-227-venv/bin/oaeval --help
 Usage: oaeval [OPTIONS] COMMAND [ARGS]...
 Open-source CLI framework for evaluating RAG systems and AI Agents.
$ /tmp/oae-227-venv/bin/oaeval --version
openagent-eval 0.4.8
```

Added `tests/unit/test_cicd/test_no_pytest_import.py` — two subprocess-based tests that block `pytest` in `sys.modules` and assert that `openagent_eval.cicd.OAEvalPlugin` and `openagent_eval.cli.main.app` import cleanly and that `oaeval --help` succeeds. Subprocess rather than in-process, because the import has already happened by the time an in-process test runs.

- [x] Unit tests pass (`uv run pytest`) — 975 passed, 4 skipped on `tests/unit`; 54 passed on `tests/integration`; full run with coverage 1029 passed, 79.61% against the 75% floor. The plugin behaves identically with pytest present.
- [ ] Linter passes (`uv run ruff check .`) — exits 1 on 229 pre-existing findings repo-wide. `plugin.py` carries the same two findings on this branch as on `main` (`UP035`, `B904`, shifted one line by the added import); the new test file has none. Zero new findings.
- [ ] Type checker passes (`uv run mypy openagent_eval/`) — see Additional Notes.
- [x] Manual testing performed

`uvx --from build python -m build` and `uvx --from twine twine check dist/*` both pass.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — the notebook workaround noted in #227 (installing pytest in its install cell) can be dropped once this lands, but that lives outside this repo
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Why lazy rather than declaring pytest a runtime dependency.** #227 offers both. Making a test framework a hard runtime requirement of an evaluation library, to satisfy an optional CI-integration module, seemed the wrong trade — it lands in every user's install to serve a path most never touch. Happy to switch if you'd prefer the dependency.

**Adjacent, not fixed:** `openagent_eval/cicd/__init__.py:14` still eagerly imports `OAEvalPlugin`, so importing anything from `openagent_eval.cicd` pulls the plugin module in. That is harmless now the pytest import is deferred, but it means any future optional CI-only dependency added to `plugin.py` reintroduces exactly this class of failure. Left alone as out of scope.

**Bug discovered while running your CI commands:** #250 — CI type-check step targets a non-existent src/ directory, so mypy has never run on the package. It is why the type-checker box above is unticked; this PR template's own checklist already names the correct path.

Generated by Claude Opus 5 (brief, review), Kimi K2.7 Code (implementation)
