### PR TITLE
fix(cli): load the config exactly once in run_command

### DIFF
--- a/openagent_eval/cli/commands/run.py
+++ b/openagent_eval/cli/commands/run.py
@@ -135,11 +135,7 @@ def run_command(
         console=console,
         disable=ctx.quiet,
     ) as progress:
-        task = progress.add_task("Loading configuration...", total=None)
-        config = load_config_from_path(path)
-        apply_output_override(config, output)
-
-        progress.update(task, description="Loading dataset...")
+        task = progress.add_task("Loading dataset...", total=None)
         dataset_items = load_dataset_for_run(config)
         total_items = len(dataset_items)
         progress.update(task, description=f"Loaded {total_items} items")

--- a/tests/unit/test_cli/test_run.py
+++ b/tests/unit/test_cli/test_run.py
@@ -1,0 +1,66 @@
+"""Tests for the oaeval run command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from openagent_eval.cli.main import app
+from openagent_eval.config.models import Config, DatasetConfig, LLMConfig, MetricsConfig
+
+runner = CliRunner()
+
+
+def _make_config() -> Config:
+    """Return a minimal valid configuration for run-command tests."""
+    return Config(
+        dataset=DatasetConfig(path="data/questions.json"),
+        llm=LLMConfig(provider="openai", model="gpt-4o"),
+        metrics=MetricsConfig(
+            retrieval=["context_precision"],
+            generation=["faithfulness"],
+        ),
+    )
+
+
+@patch("openagent_eval.cli.commands.run.load_config_from_path")
+@patch("openagent_eval.cli.commands.run.load_dataset_for_run")
+@patch("openagent_eval.cli.commands.run.execute_evaluation")
+@patch("openagent_eval.cli.commands.run.ReportManager")
+def test_run_loads_config_exactly_once(
+    mock_manager_class: MagicMock,
+    mock_execute: MagicMock,
+    mock_load_dataset: MagicMock,
+    mock_load_config: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Regression test for #41: config must be parsed from disk exactly once.
+
+    The pre-fix implementation loaded the configuration a second time inside the
+    Progress context, so this test patches the function ``run.py`` imports and
+    asserts it is called only once for a normal (non-dry-run) invocation.
+    """
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("dataset: data/questions.json\n", encoding="utf-8")
+
+    config = _make_config()
+    mock_load_config.return_value = config
+    mock_load_dataset.return_value = [
+        {
+            "question": "What is Python?",
+            "ground_truth": "A programming language.",
+            "context": "Python is a language.",
+        }
+    ]
+    mock_execute.return_value = MagicMock(summary={"score": 1.0})
+
+    mock_manager = MagicMock()
+    mock_manager.save_report.return_value = tmp_path / "report.json"
+    mock_manager_class.return_value = mock_manager
+
+    result = runner.invoke(app, ["--quiet", "run", str(config_path)])
+
+    assert result.exit_code == 0, result.output
+    mock_load_config.assert_called_once_with(Path(config_path))


### PR DESCRIPTION
## Description

`run_command()` parsed the config file from disk twice — once at the top, before the dry-run check, and again inside the progress context, where the second `load_config_from_path()` overwrote the `config` variable entirely. The first parse and its `apply_output_override()` were dead work on every non-dry-run invocation, and if the file changed between the two reads the run would silently use the second one. This loads it once and reuses it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] CI/CD update

## Related Issues

Closes #41

## How Has This Been Tested?

Added `test_run_loads_config_exactly_once`, which patches `load_config_from_path` at the name `run.py` imports it under and counts real invocations for a normal (non-dry-run) run.

Proved the test bites rather than assuming it: with the new test kept and only `openagent_eval/cli/commands/run.py` restored to `main`, it fails with `AssertionError: Expected 'load_config_from_path' to be called once. Called 2 times.`; with the fix in place it passes. Verified independently of the change's author.

- [x] Unit tests pass (`uv run pytest`) — `tests/unit` and `tests/integration` both green.
- [ ] Linter passes (`uv run ruff check .`) — exits 1 on 221 pre-existing findings repo-wide, and reports the identical set at this branchpoint and on `main`. Both files this PR touches are clean under `ruff check` in both states, and `ruff format --diff` on `run.py` is byte-identical between base and branch apart from line-number offsets. Zero new findings.
- [ ] Type checker passes (`uv run mypy openagent_eval/`) — not run; see Additional Notes.
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — no new code needed explaining; the change is a deletion plus a progress-label correction
- [ ] I have made corresponding changes to the documentation — none needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**The progress label changed.** With the second load gone, no configuration work happens inside the progress context, so the first task there is now the dataset step rather than "Loading configuration…" — leaving the old label would have described work that no longer occurs.

**#42 is already fixed on `main`, so this PR does not touch it.** The branch name mentions it because it was picked up alongside #41, but `cli/main.py` on `main` already uses distinct `cli_ctx` and `click_ctx` names — exactly what #42's own suggested fix proposes. It appears to have been resolved under the duplicate #99. Nothing to change; I've noted it on the issue so it can be closed.

**Type-checker box.** Unticked because I did not run `mypy openagent_eval/`. CI's own step targets a non-existent `src/` — that is #250, already filed.

Generated by Claude Opus 5 (brief, review), Kimi K2.7 Code (implementation), Claude Sonnet 5 (verification)
