### PR TITLE
fix(corpus): reject unknown audit check names instead of silently skipping them

### DIFF
--- a/openagent_eval/corpus/auditor.py
+++ b/openagent_eval/corpus/auditor.py
@@ -161,11 +161,18 @@ class CorpusAuditor:
         if self.checks is None:
             return list(all_analyzers.values())
 
-        return [
-            all_analyzers[name]
-            for name in self.checks
-            if name in all_analyzers
-        ]
+        unknown = [name for name in self.checks if name not in all_analyzers]
+        if unknown:
+            valid = sorted(all_analyzers)
+            raise CorpusValidationError(
+                message=(
+                    f"Unknown corpus check(s): {', '.join(unknown)}. "
+                    f"Valid checks are: {', '.join(valid)}."
+                ),
+                validation_errors=[f"unrecognized check: {name}" for name in unknown],
+            )
+
+        return [all_analyzers[name] for name in self.checks]
 
     def _load_documents(self, path: Path) -> list[CorpusDocument]:
         """Load documents from a directory or single file.

--- a/openagent_eval/corpus/staleness.py
+++ b/openagent_eval/corpus/staleness.py
@@ -224,8 +224,6 @@ class StalenessDetector(BaseCorpusAnalyzer):
             Parsed datetime or None.
         """
         # Normalize timezone format: +00:00 -> +0000
-        import re
-
         normalized = re.sub(r"([+-]\d{2}):(\d{2})$", r"\1\2", date_str.strip())
 
         formats = [

--- a/tests/unit/test_corpus/test_auditor.py
+++ b/tests/unit/test_corpus/test_auditor.py
@@ -95,6 +95,28 @@ class TestCorpusAuditor:
         assert "contradiction" not in report.checks_performed
         assert "duplicate" not in report.checks_performed
 
+    def test_build_analyzers_rejects_unknown_check_names(self):
+        """Unknown check names must raise CorpusValidationError. (issue #56)"""
+        auditor = CorpusAuditor(checks=["staleness", "contradction"])
+
+        with pytest.raises(CorpusValidationError, match="contradction") as exc_info:
+            auditor._build_analyzers()
+
+        message = str(exc_info.value)
+        assert "contradction" in message
+        assert "staleness" in message  # valid name listed
+        assert "contradiction" in message  # valid name listed
+
+    @pytest.mark.asyncio
+    async def test_audit_with_valid_checks_still_works(self, temp_corpus):
+        """A fully valid check list still produces a normal audit report."""
+        auditor = CorpusAuditor(checks=["staleness", "duplicate"])
+        report = await auditor.audit(str(temp_corpus))
+
+        assert report.total_documents == 3
+        assert "staleness" in report.checks_performed
+        assert "duplicate" in report.checks_performed
+
     @pytest.mark.asyncio
     async def test_max_documents_limit(self, tmp_path):
         """Test max documents limit is respected."""


### PR DESCRIPTION
## Description

Two independent corpus-layer fixes.

`CorpusAuditor._build_analyzers()` filtered its check list with `if name in all_analyzers`, so an unrecognised check name was silently dropped — a typo like `"contradction"` produced an audit that never ran the contradiction check, with nothing in the report or the output to say so. It now raises `CorpusValidationError` naming every unknown check and listing the valid ones.

Separately, `StalenessDetector._parse_date_string()` carried a local `import re` shadowing the module-level import at the top of the same file; removed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update
- [ ] CI/CD update

## Related Issues

Closes #56
Closes #61

## How Has This Been Tested?

Added `test_build_analyzers_rejects_unknown_check_names` and `test_audit_with_valid_checks_still_works`.

Proved the first test bites: with it kept and only `openagent_eval/corpus/auditor.py` restored to `main`, it fails with `Failed: DID NOT RAISE CorpusValidationError`; with the fix it passes. The observed message for a two-typo list is:

```
Unknown corpus check(s): contradction, duplcate. Valid checks are: contradiction, coverage, duplicate, staleness.
```

One raise for all unknown names rather than one per name, and a fully valid list still builds.

- [x] Unit tests pass (`uv run pytest`) — full suite 1029 passed, 4 skipped. The test diff against `main` is purely additive (`1 file changed, 22 insertions(+), 0 deletions(-)`); no pre-existing test was modified, skipped or weakened to accommodate the new behaviour.
- [ ] Linter passes (`uv run ruff check .`) — exits 1 on pre-existing findings repo-wide, identical at this branchpoint and on `main`. No new findings on the three files touched here.
- [ ] Type checker passes (`uv run mypy openagent_eval/`) — not run; CI's step targets a non-existent `src/`, which is #250.
- [x] Manual testing performed — constructed `CorpusAuditor` directly with one bad name, with two bad names, and with a fully valid list, and read the real exception messages quoted above.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — the raise is self-describing; nothing else warranted a comment
- [ ] I have made corresponding changes to the documentation — none needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**This does change behaviour for callers passing an unknown check name — please sanity-check the call.** #56 offered three options: warn, raise, or both. I picked raise, on the reasoning that a warning still hands back an audit report that is silently incomplete, which is the harm the issue describes, and a construction-time failure is cheap for the user to correct. Nothing in this repo passes a junk check name, so no existing test or caller is affected. If you would rather it warn and continue — or warn on unknown names while still running the known ones — say so and I will switch it; your call, not mine.

`CorpusValidationError` is the exception the corpus layer already uses for this class of problem (`openagent_eval/exceptions/corpus.py`), and `auditor.py` already raised it on the no-readable-documents path, so this introduces no new error type.

Generated by Claude Opus 5 (brief, review), Kimi K2.7 Code (implementation), Claude Sonnet 5 (verification)
