### PR TITLE
fix(pipeline): replace private-attribute and name-based provider coupling with public contracts

### DIFF
--- a/openagent_eval/core/pipeline.py
+++ b/openagent_eval/core/pipeline.py
@@ -221,7 +221,7 @@ class Pipeline:
         prompt_tokens = token_usage.prompt_tokens if token_usage else 0
         completion_tokens = token_usage.completion_tokens if token_usage else 0
         provider_name = getattr(self._llm, "name", None)
-        model_name = getattr(self._llm, "_model", None) or self.config.llm.model
+        model_name = getattr(self._llm, "model_name", None) or self.config.llm.model
 
         for name, metric in self._metrics:
             try:

--- a/openagent_eval/core/pipeline.py
+++ b/openagent_eval/core/pipeline.py
@@ -167,12 +167,9 @@ class Pipeline:
         """Retrieve contexts for a question, or fall back to dataset context."""
         if self._retriever is not None:
             try:
-                if getattr(self._retriever, "name", None) == "mock":
-                    docs = await self._retriever.retrieve(
-                        question, k=self._k, ground_truth_contexts=gt_contexts
-                    )
-                else:
-                    docs = await self._retriever.retrieve(question, k=self._k)
+                docs = await self._retriever.retrieve(
+                    question, k=self._k, ground_truth_contexts=gt_contexts
+                )
                 return [doc.content for doc in docs]
             except Exception:
                 # Retrieval failure -> fall back to any dataset-provided context.

--- a/openagent_eval/core/pipeline.py
+++ b/openagent_eval/core/pipeline.py
@@ -11,6 +11,7 @@ registry. Each item is evaluated independently so the loop can run in parallel.
 
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -65,6 +66,7 @@ class Pipeline:
         self._metrics: list[tuple[str, BaseMetric]] = metrics or []
         self._executor = executor
         self._k = self._resolve_k()
+        self._retriever_supports_ground_truth_contexts: bool | None = None
 
     # ------------------------------------------------------------------ #
     # Public API                                                          #
@@ -121,8 +123,13 @@ class Pipeline:
 
             # 3. Metrics
             metrics, metric_errors = self._run_metrics(
-                question, answer, ground_truth, contexts, gt_contexts,
-                latency_ms, token_usage,
+                question,
+                answer,
+                ground_truth,
+                contexts,
+                gt_contexts,
+                latency_ms,
+                token_usage,
             )
 
             return EvaluationResult(
@@ -134,7 +141,9 @@ class Pipeline:
                 metadata={
                     "latency_ms": latency_ms,
                     "prompt_tokens": token_usage.prompt_tokens if token_usage else None,
-                    "completion_tokens": token_usage.completion_tokens if token_usage else None,
+                    "completion_tokens": token_usage.completion_tokens
+                    if token_usage
+                    else None,
                     "total_tokens": token_usage.total_tokens if token_usage else None,
                     "metric_errors": metric_errors,
                     **item.get("metadata", {}),
@@ -161,15 +170,56 @@ class Pipeline:
     # Steps                                                               #
     # ------------------------------------------------------------------ #
 
+    def _supports_ground_truth_contexts(self) -> bool:
+        """Return whether the injected retriever accepts ``ground_truth_contexts``.
+
+        The result is cached on the pipeline instance because it is computed
+        with reflection and must not run inside the per-item retrieval hot loop.
+        A retriever is treated as supporting the parameter if its bound
+        ``retrieve`` method has a parameter named ``ground_truth_contexts`` or
+        accepts arbitrary keyword arguments (``**kwargs``).
+        """
+        if self._retriever_supports_ground_truth_contexts is not None:
+            return self._retriever_supports_ground_truth_contexts
+
+        if self._retriever is None:
+            self._retriever_supports_ground_truth_contexts = False
+            return False
+
+        retrieve_method = getattr(self._retriever, "retrieve", None)
+        if retrieve_method is None:
+            self._retriever_supports_ground_truth_contexts = False
+            return False
+
+        try:
+            sig = inspect.signature(retrieve_method)
+        except (ValueError, TypeError):
+            self._retriever_supports_ground_truth_contexts = False
+            return False
+
+        for param in sig.parameters.values():
+            if param.kind == inspect.Parameter.VAR_KEYWORD:
+                self._retriever_supports_ground_truth_contexts = True
+                return True
+            if param.name == "ground_truth_contexts":
+                self._retriever_supports_ground_truth_contexts = True
+                return True
+
+        self._retriever_supports_ground_truth_contexts = False
+        return False
+
     async def _retrieve(
         self, question: str, context: str | None, gt_contexts: list[str]
     ) -> list[str]:
         """Retrieve contexts for a question, or fall back to dataset context."""
         if self._retriever is not None:
             try:
-                docs = await self._retriever.retrieve(
-                    question, k=self._k, ground_truth_contexts=gt_contexts
-                )
+                if self._supports_ground_truth_contexts():
+                    docs = await self._retriever.retrieve(
+                        question, k=self._k, ground_truth_contexts=gt_contexts
+                    )
+                else:
+                    docs = await self._retriever.retrieve(question, k=self._k)
                 return [doc.content for doc in docs]
             except Exception:
                 # Retrieval failure -> fall back to any dataset-provided context.
@@ -190,7 +240,9 @@ class Pipeline:
             return "", None, None
 
         try:
-            response = await self._llm.generate_with_usage(prompt, ground_truth=ground_truth)
+            response = await self._llm.generate_with_usage(
+                prompt, ground_truth=ground_truth
+            )
             return response.content, response.usage, response.latency_ms
         except Exception:
             # Generation failure -> empty answer; metrics will report accordingly.
@@ -290,9 +342,7 @@ class Pipeline:
             if metric_counts[name] > 0
         }
 
-        total_tokens = sum(
-            (r.metadata.get("total_tokens") or 0) for r in results
-        )
+        total_tokens = sum((r.metadata.get("total_tokens") or 0) for r in results)
         latencies = [
             r.metadata.get("latency_ms")
             for r in results

--- a/openagent_eval/providers/base/llm.py
+++ b/openagent_eval/providers/base/llm.py
@@ -82,6 +82,22 @@ class LLMProvider(ABC):
         """
         pass
 
+    @property
+    def model_name(self) -> str | None:
+        """Return the model identifier currently in use by this provider.
+
+        Subclasses should override this property to report the actual model
+        identifier (e.g. ``"gpt-4o"``). The default implementation returns
+        ``None`` so that legacy third-party providers that do not define it
+        keep working; callers should fall back to ``config.llm.model`` when
+        this property returns ``None``.
+
+        Returns:
+            The model identifier in use, or ``None`` if the provider does not
+            expose one.
+        """
+        return None
+
     def validate_inputs(self, **kwargs: Any) -> None:  # noqa: B027
         """Validate provider inputs before execution.
 

--- a/openagent_eval/providers/base/retriever.py
+++ b/openagent_eval/providers/base/retriever.py
@@ -43,12 +43,22 @@ class Retriever(ABC):
     description: str
 
     @abstractmethod
-    async def retrieve(self, query: str, k: int = 5) -> list[Document]:
+    async def retrieve(
+        self,
+        query: str,
+        k: int = 5,
+        *,
+        ground_truth_contexts: list[str] | None = None,
+    ) -> list[Document]:
         """Retrieve relevant documents for a given query.
 
         Args:
             query: The search query string.
             k: Number of documents to retrieve (default: 5).
+            ground_truth_contexts: Optional ground-truth contexts supplied by the
+                dataset. Retrievers that can use them (e.g. the mock retriever)
+                may return them; retrievers that do not use them must accept and
+                ignore the parameter.
 
         Returns:
             List of Document objects matching the query.

--- a/openagent_eval/providers/llm/anthropic.py
+++ b/openagent_eval/providers/llm/anthropic.py
@@ -139,6 +139,11 @@ class Anthropic(LLMProvider):
 
         self._client = anthropic.AsyncAnthropic(api_key=api_key)
 
+    @property
+    def model_name(self) -> str | None:
+        """Return the configured Anthropic model identifier."""
+        return self.model
+
     async def generate(self, prompt: str, **kwargs: Any) -> str:
         """Generate a response from the LLM.
 

--- a/openagent_eval/providers/llm/gemini.py
+++ b/openagent_eval/providers/llm/gemini.py
@@ -150,6 +150,11 @@ class Gemini(LLMProvider):
                 original_error=exc,
             ) from exc
 
+    @property
+    def model_name(self) -> str | None:
+        """Return the configured Gemini model identifier."""
+        return self._model
+
     async def generate_with_usage(self, prompt: str, **kwargs: Any) -> LLMResponse:
         """Generate a response and return it with token usage and latency.
 

--- a/openagent_eval/providers/llm/groq.py
+++ b/openagent_eval/providers/llm/groq.py
@@ -139,6 +139,11 @@ class Groq(LLMProvider):
                 original_error=e,
             ) from e
 
+    @property
+    def model_name(self) -> str | None:
+        """Return the configured Groq model identifier."""
+        return self.model
+
     async def generate(self, prompt: str, **kwargs: Any) -> str:
         """Generate a response from the LLM.
 

--- a/openagent_eval/providers/llm/mock.py
+++ b/openagent_eval/providers/llm/mock.py
@@ -44,6 +44,11 @@ class MockLLMProvider(LLMProvider):
         self._model = getattr(config, "model", model) or model
         self._temperature = getattr(config, "temperature", temperature) or temperature
 
+    @property
+    def model_name(self) -> str | None:
+        """Return the configured mock model identifier."""
+        return self._model
+
     async def generate(self, prompt: str, **kwargs: Any) -> str:
         """Return a deterministic answer without calling any API.
 

--- a/openagent_eval/providers/llm/ollama.py
+++ b/openagent_eval/providers/llm/ollama.py
@@ -145,6 +145,11 @@ class Ollama(LLMProvider):
             headers={"Content-Type": "application/json"},
         )
 
+    @property
+    def model_name(self) -> str | None:
+        """Return the configured Ollama model identifier."""
+        return self._model
+
     async def generate(self, prompt: str, **kwargs: Any) -> str:
         """Generate a response from the Ollama model.
 

--- a/openagent_eval/providers/llm/openai.py
+++ b/openagent_eval/providers/llm/openai.py
@@ -136,6 +136,11 @@ class OpenAIProvider(LLMProvider):
         self._client = AsyncOpenAI(api_key=self._api_key)
         self._encoding: tiktoken.Encoding | None = None
 
+    @property
+    def model_name(self) -> str | None:
+        """Return the configured OpenAI model identifier."""
+        return self._model
+
     def _get_encoding(self) -> tiktoken.Encoding:
         """Get or create tiktoken encoding for the configured model.
 

--- a/openagent_eval/providers/llm/openrouter.py
+++ b/openagent_eval/providers/llm/openrouter.py
@@ -122,6 +122,11 @@ class OpenRouter(LLMProvider):
         self.max_tokens = max_tokens
         self.base_url = base_url.rstrip("/")
 
+    @property
+    def model_name(self) -> str | None:
+        """Return the configured OpenRouter model identifier."""
+        return self.model
+
     async def generate_with_usage(self, prompt: str, **kwargs: Any) -> "LLMResponse":
         """Generate a response and return it with token usage and latency.
 

--- a/openagent_eval/providers/retrievers/bm25.py
+++ b/openagent_eval/providers/retrievers/bm25.py
@@ -108,7 +108,13 @@ class BM25Retriever(Retriever):
                 original_error=exc,
             ) from exc
 
-    async def retrieve(self, query: str, k: int = 5) -> list[Document]:
+    async def retrieve(
+        self,
+        query: str,
+        k: int = 5,
+        *,
+        ground_truth_contexts: list[str] | None = None,
+    ) -> list[Document]:
         """Retrieve the ``k`` highest BM25-scoring documents."""
         self.validate_inputs(query=query, k=k)
         k = k or self._k

--- a/openagent_eval/providers/retrievers/chroma.py
+++ b/openagent_eval/providers/retrievers/chroma.py
@@ -125,7 +125,13 @@ class ChromaRetriever(Retriever):
                 original_error=exc,
             ) from exc
 
-    async def retrieve(self, query: str, k: int = 5) -> list[Document]:
+    async def retrieve(
+        self,
+        query: str,
+        k: int = 5,
+        *,
+        ground_truth_contexts: list[str] | None = None,
+    ) -> list[Document]:
         """Retrieve relevant documents for a given query.
 
         Args:

--- a/openagent_eval/providers/retrievers/elasticsearch.py
+++ b/openagent_eval/providers/retrievers/elasticsearch.py
@@ -77,7 +77,13 @@ class ElasticsearchRetriever(Retriever):
                 original_error=exc,
             ) from exc
 
-    async def retrieve(self, query: str, k: int = 5) -> list[Document]:
+    async def retrieve(
+        self,
+        query: str,
+        k: int = 5,
+        *,
+        ground_truth_contexts: list[str] | None = None,
+    ) -> list[Document]:
         """Run a lexical or kNN search and normalize scores."""
         self.validate_inputs(query=query, k=k)
         try:

--- a/openagent_eval/providers/retrievers/faiss.py
+++ b/openagent_eval/providers/retrievers/faiss.py
@@ -102,7 +102,13 @@ class FAISSRetriever(Retriever):
                 original_error=exc,
             ) from exc
 
-    async def retrieve(self, query: str, k: int = 5) -> list[Document]:
+    async def retrieve(
+        self,
+        query: str,
+        k: int = 5,
+        *,
+        ground_truth_contexts: list[str] | None = None,
+    ) -> list[Document]:
         """Embed the query and search the FAISS index."""
         self.validate_inputs(query=query, k=k)
         k = k or self._k

--- a/openagent_eval/providers/retrievers/http.py
+++ b/openagent_eval/providers/retrievers/http.py
@@ -121,7 +121,13 @@ class HttpRetriever(Retriever):
         self._score_mode = score_mode
         self._timeout = timeout
 
-    async def retrieve(self, query: str, k: int = 5) -> list[Document]:
+    async def retrieve(
+        self,
+        query: str,
+        k: int = 5,
+        *,
+        ground_truth_contexts: list[str] | None = None,
+    ) -> list[Document]:
         """Send the query to the endpoint and map the response to Documents."""
         self.validate_inputs(query=query, k=k)
 

--- a/openagent_eval/providers/retrievers/memory.py
+++ b/openagent_eval/providers/retrievers/memory.py
@@ -120,7 +120,13 @@ class MemoryRetriever(Retriever):
                 original_error=exc,
             ) from exc
 
-    async def retrieve(self, query: str, k: int = 5) -> list[Document]:
+    async def retrieve(
+        self,
+        query: str,
+        k: int = 5,
+        *,
+        ground_truth_contexts: list[str] | None = None,
+    ) -> list[Document]:
         """Retrieve the ``k`` most similar documents to ``query``.
 
         Args:

--- a/openagent_eval/providers/retrievers/mock.py
+++ b/openagent_eval/providers/retrievers/mock.py
@@ -30,7 +30,14 @@ class MockRetriever(Retriever):
         """
         self.collection_name = collection_name
 
-    async def retrieve(self, query: str, k: int = 5, **kwargs: Any) -> list[Document]:
+    async def retrieve(
+        self,
+        query: str,
+        k: int = 5,
+        *,
+        ground_truth_contexts: list[str] | None = None,
+        **kwargs: Any,
+    ) -> list[Document]:
         """Return retrieved documents without a vector store.
 
         Args:
@@ -44,8 +51,7 @@ class MockRetriever(Retriever):
         """
         self.validate_inputs(query=query, k=k)
 
-        gt_contexts = kwargs.get("ground_truth_contexts")
-        if gt_contexts:
+        if ground_truth_contexts:
             return [
                 Document(
                     content=ctx,
@@ -53,7 +59,7 @@ class MockRetriever(Retriever):
                     score=1.0,
                     id=f"gt-{i}",
                 )
-                for i, ctx in enumerate(gt_contexts[:k])
+                for i, ctx in enumerate(ground_truth_contexts[:k])
             ]
 
         docs: list[Document] = []

--- a/openagent_eval/providers/retrievers/pgvector.py
+++ b/openagent_eval/providers/retrievers/pgvector.py
@@ -88,7 +88,13 @@ class PGVectorRetriever(Retriever):
                 original_error=exc,
             ) from exc
 
-    async def retrieve(self, query: str, k: int = 5) -> list[Document]:
+    async def retrieve(
+        self,
+        query: str,
+        k: int = 5,
+        *,
+        ground_truth_contexts: list[str] | None = None,
+    ) -> list[Document]:
         """Embed the query and run a similarity SQL query."""
         self.validate_inputs(query=query, k=k)
 

--- a/openagent_eval/providers/retrievers/pinecone.py
+++ b/openagent_eval/providers/retrievers/pinecone.py
@@ -69,7 +69,13 @@ class PineconeRetriever(Retriever):
                 original_error=exc,
             ) from exc
 
-    async def retrieve(self, query: str, k: int = 5) -> list[Document]:
+    async def retrieve(
+        self,
+        query: str,
+        k: int = 5,
+        *,
+        ground_truth_contexts: list[str] | None = None,
+    ) -> list[Document]:
         """Embed the query and query the Pinecone index."""
         self.validate_inputs(query=query, k=k)
         try:

--- a/openagent_eval/providers/retrievers/qdrant.py
+++ b/openagent_eval/providers/retrievers/qdrant.py
@@ -80,7 +80,13 @@ class QdrantRetriever(Retriever):
                 original_error=exc,
             ) from exc
 
-    async def retrieve(self, query: str, k: int = 5) -> list[Document]:
+    async def retrieve(
+        self,
+        query: str,
+        k: int = 5,
+        *,
+        ground_truth_contexts: list[str] | None = None,
+    ) -> list[Document]:
         """Embed the query and search the Qdrant collection."""
         self.validate_inputs(query=query, k=k)
         try:

--- a/openagent_eval/providers/retrievers/weaviate.py
+++ b/openagent_eval/providers/retrievers/weaviate.py
@@ -73,7 +73,13 @@ class WeaviateRetriever(Retriever):
                 original_error=exc,
             ) from exc
 
-    async def retrieve(self, query: str, k: int = 5) -> list[Document]:
+    async def retrieve(
+        self,
+        query: str,
+        k: int = 5,
+        *,
+        ground_truth_contexts: list[str] | None = None,
+    ) -> list[Document]:
         """Search the Weaviate collection near the query text."""
         self.validate_inputs(query=query, k=k)
         try:

--- a/tests/unit/test_core/test_pipeline_model_name.py
+++ b/tests/unit/test_core/test_pipeline_model_name.py
@@ -1,0 +1,100 @@
+"""Regression test for issue #51.
+
+Verifies that ``openagent_eval/core/pipeline.py`` reads the LLM model
+identifier through the public ``LLMProvider.model_name`` property rather than
+reaching into a private ``_model`` attribute.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from openagent_eval.config.models import (
+    Config,
+    DatasetConfig,
+    LLMConfig,
+    MetricsConfig,
+    ReportConfig,
+    RetrieverConfig,
+)
+from openagent_eval.core.pipeline import Pipeline
+from openagent_eval.metrics.base import BaseMetric, MetricResult
+from openagent_eval.providers.base.llm import LLMProvider
+from openagent_eval.providers.models import LLMResponse, TokenUsage
+
+
+class _ModelNameCapturingMetric(BaseMetric):
+    """Metric that records the ``model`` argument it receives."""
+
+    name = "model_name_capture"
+    description = "Captures the model name passed by the pipeline"
+
+    def __init__(self) -> None:
+        self.captured_model: str | None = None
+
+    def evaluate(self, **kwargs: Any) -> MetricResult:
+        self.captured_model = kwargs.get("model")
+        return MetricResult(score=1.0, reason="captured")
+
+
+class _FakeLLMProvider(LLMProvider):
+    """Fake LLM provider that exposes ``model_name`` but not ``_model``.
+
+    This proves the pipeline uses the public property: the provider's
+    ``model_name`` differs from ``config.llm.model``, so a fallback to the
+    config value is visibly distinguishable from a real read.
+    """
+
+    name = "fake"
+    description = "Fake provider for regression testing"
+
+    def __init__(self, model_name: str) -> None:
+        # Intentionally no ``_model`` attribute.
+        self._reported_model = model_name
+
+    @property
+    def model_name(self) -> str | None:
+        return self._reported_model
+
+    async def generate(self, prompt: str, **kwargs: Any) -> str:
+        return "fake answer"
+
+    async def get_token_count(self, text: str) -> int:
+        return 0
+
+    async def generate_with_usage(self, prompt: str, **kwargs: Any) -> LLMResponse:
+        return LLMResponse(
+            content="fake answer",
+            model=self._reported_model,
+            usage=TokenUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            provider=self.name,
+            latency_ms=1.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_uses_public_model_name_property() -> None:
+    """A provider exposing only ``model_name`` has it forwarded to metrics."""
+    config_model = "config-model"
+    provider_model = "provider-specific-model"
+
+    config = Config(
+        dataset=DatasetConfig(path="data/questions.json"),
+        llm=LLMConfig(provider="fake", model=config_model),
+        retriever=RetrieverConfig(provider="mock"),
+        metrics=MetricsConfig(),
+        report=ReportConfig(),
+        parallel=False,
+    )
+
+    llm = _FakeLLMProvider(model_name=provider_model)
+    capture_metric = _ModelNameCapturingMetric()
+    pipeline = Pipeline(config, llm=llm, metrics=[("model_name_capture", capture_metric)])
+
+    await pipeline.execute(
+        [{"question": "What is RAG?", "ground_truth": "RAG is retrieval augmented generation."}]
+    )
+
+    assert capture_metric.captured_model == provider_model

--- a/tests/unit/test_core/test_pipeline_model_name.py
+++ b/tests/unit/test_core/test_pipeline_model_name.py
@@ -91,10 +91,17 @@ async def test_pipeline_uses_public_model_name_property() -> None:
 
     llm = _FakeLLMProvider(model_name=provider_model)
     capture_metric = _ModelNameCapturingMetric()
-    pipeline = Pipeline(config, llm=llm, metrics=[("model_name_capture", capture_metric)])
+    pipeline = Pipeline(
+        config, llm=llm, metrics=[("model_name_capture", capture_metric)]
+    )
 
     await pipeline.execute(
-        [{"question": "What is RAG?", "ground_truth": "RAG is retrieval augmented generation."}]
+        [
+            {
+                "question": "What is RAG?",
+                "ground_truth": "RAG is retrieval augmented generation.",
+            }
+        ]
     )
 
     assert capture_metric.captured_model == provider_model

--- a/tests/unit/test_core/test_pipeline_retriever_contract.py
+++ b/tests/unit/test_core/test_pipeline_retriever_contract.py
@@ -1,0 +1,83 @@
+"""Regression test for issue #53.
+
+Verifies that ``openagent_eval/core/pipeline.py`` passes
+``ground_truth_contexts`` to every retriever through the public
+``Retriever.retrieve`` signature instead of special-casing the mock retriever
+by name.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openagent_eval.config.models import (
+    Config,
+    DatasetConfig,
+    LLMConfig,
+    MetricsConfig,
+    ReportConfig,
+    RetrieverConfig,
+)
+from openagent_eval.core.pipeline import Pipeline
+from openagent_eval.providers.base.retriever import Retriever
+from openagent_eval.providers.models import Document
+
+
+class _NonMockRetriever(Retriever):
+    """Non-mock retriever that records the ground_truth_contexts it receives."""
+
+    name = "not-mock"
+    description = "Records ground_truth_contexts for regression testing"
+
+    def __init__(self) -> None:
+        self.captured_ground_truth_contexts: list[str] | None = None
+
+    async def retrieve(
+        self,
+        query: str,
+        k: int = 5,
+        *,
+        ground_truth_contexts: list[str] | None = None,
+    ) -> list[Document]:
+        self.captured_ground_truth_contexts = ground_truth_contexts
+        return [
+            Document(
+                content="retrieved context",
+                score=1.0,
+                id="doc-1",
+            )
+        ]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_passes_ground_truth_contexts_to_non_mock_retriever() -> None:
+    """A retriever whose name is not ``mock`` still receives ground_truth_contexts."""
+    expected_contexts = ["ground truth context one", "ground truth context two"]
+
+    # A minimal fake LLM so the pipeline can run generation. The provider is not
+    # the subject of this test.
+    from openagent_eval.providers.llm.mock import MockLLMProvider
+
+    config = Config(
+        dataset=DatasetConfig(path="data/questions.json"),
+        llm=LLMConfig(provider="mock", model="mock-model"),
+        retriever=RetrieverConfig(provider="not-mock"),
+        metrics=MetricsConfig(),
+        report=ReportConfig(),
+        parallel=False,
+    )
+
+    retriever = _NonMockRetriever()
+    pipeline = Pipeline(config, retriever=retriever, llm=MockLLMProvider())
+
+    await pipeline.execute(
+        [
+            {
+                "question": "What is RAG?",
+                "ground_truth": "RAG is retrieval augmented generation.",
+                "ground_truth_contexts": expected_contexts,
+            }
+        ]
+    )
+
+    assert retriever.captured_ground_truth_contexts == expected_contexts

--- a/tests/unit/test_core/test_pipeline_retriever_contract.py
+++ b/tests/unit/test_core/test_pipeline_retriever_contract.py
@@ -49,6 +49,16 @@ class _NonMockRetriever(Retriever):
         ]
 
 
+class _LegacyRetriever(Retriever):
+    """Out-of-tree retriever written against the old two-argument signature."""
+
+    name = "legacy"
+    description = "Legacy retriever with no ground_truth_contexts support"
+
+    async def retrieve(self, query: str, k: int = 5) -> list[Document]:
+        return [Document(content=f"legacy doc for {query}", score=1.0, id="legacy-1")]
+
+
 @pytest.mark.asyncio
 async def test_pipeline_passes_ground_truth_contexts_to_non_mock_retriever() -> None:
     """A retriever whose name is not ``mock`` still receives ground_truth_contexts."""
@@ -81,3 +91,40 @@ async def test_pipeline_passes_ground_truth_contexts_to_non_mock_retriever() -> 
     )
 
     assert retriever.captured_ground_truth_contexts == expected_contexts
+
+
+@pytest.mark.asyncio
+async def test_pipeline_keeps_legacy_retriever_working() -> None:
+    """A retriever with the old two-argument signature still returns documents.
+
+    Before the capability-detection fix, the pipeline unconditionally passed
+    ``ground_truth_contexts`` to every retriever. A legacy retriever raised
+    ``TypeError``, which was swallowed by the bare ``except Exception`` in
+    ``_retrieve``, causing it to silently return no documents. This test
+    asserts that the legacy retriever's documents actually reach the result.
+    """
+    from openagent_eval.providers.llm.mock import MockLLMProvider
+
+    config = Config(
+        dataset=DatasetConfig(path="data/questions.json"),
+        llm=LLMConfig(provider="mock", model="mock-model"),
+        retriever=RetrieverConfig(provider="legacy"),
+        metrics=MetricsConfig(),
+        report=ReportConfig(),
+        parallel=False,
+    )
+
+    retriever = _LegacyRetriever()
+    pipeline = Pipeline(config, retriever=retriever, llm=MockLLMProvider())
+
+    result = await pipeline.execute(
+        [
+            {
+                "question": "What is RAG?",
+                "ground_truth": "RAG is retrieval augmented generation.",
+                "ground_truth_contexts": ["expected gt context"],
+            }
+        ]
+    )
+
+    assert result.results[0].contexts == ["legacy doc for What is RAG?"]


### PR DESCRIPTION
## Description

Two places where `core/pipeline.py` reached into provider internals instead of a declared contract. #51: the model name for metrics came from the private `self._llm._model`, silently falling back to the config value for any provider naming that attribute differently. #53: `_retrieve` branched on `getattr(self._retriever, "name", None) == "mock"` to decide whether to pass ground-truth contexts, so the core pipeline knew one retriever by name and no other retriever could ever opt in.

Both are fixed by *adding* the missing public contract rather than removing anything: a `model_name` property on the LLM provider base, and `ground_truth_contexts` as a real parameter on `Retriever.retrieve()`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] CI/CD update

## Related Issues

Closes #51
Closes #53

## How Has This Been Tested?

Three regression tests, each verified to fail on the code it targets and pass after:

- `test_pipeline_uses_public_model_name_property` — a fake provider exposing `model_name` and *not* `_model`, with a model id deliberately different from the config's, so a silent fallback is distinguishable from a real read. Pre-fix: `AssertionError: assert 'config-model' == 'provider-specific-model'`.
- `test_pipeline_passes_ground_truth_contexts_to_non_mock_retriever` — asserts on the argument the retriever actually received. Pre-fix: `AssertionError: assert None == ['ground truth context one', 'ground truth context two']`.
- `test_pipeline_keeps_legacy_retriever_working` — a retriever with the *old* two-argument signature must still have its documents reach the result. Pre-fix (against the intermediate commit, before the compatibility fix): `AssertionError: assert [] == ['legacy doc for What is RAG?']`.

Behaviour was also probed directly, per case: a retriever declaring the parameter receives it; one accepting `**kwargs` receives it; a legacy retriever is called without it and returns its real documents; `MockRetriever` receives it and behaves exactly as before.

- [x] Unit tests pass (`uv run pytest`) — full run 1030 passed, 4 skipped; coverage 79.60% against the 75% floor.
- [ ] Linter passes (`uv run ruff check .`) — exits 1 on the same pre-existing findings as `main`; no new finding on any file this PR touches.
- [ ] Type checker passes (`uv run mypy openagent_eval/`) — not run; CI's step targets a non-existent `src/`, which is #250.
- [x] Manual testing performed — the four retriever cases above, plus an instrumented run confirming the signature check is cached.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — none needed; both additions are backward-compatible defaults
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Why capability detection rather than just passing the new argument.** Removing the `"mock"` check means the pipeline passes `ground_truth_contexts` to *every* retriever. All eleven retrievers in this repo were updated to accept it, so the suite goes green either way — but an out-of-tree `Retriever` subclass written against `retrieve(self, query, k=5)` would raise `TypeError`, and `_retrieve`'s `except Exception` would absorb it silently, degrading that user's retrieval to the dataset fallback on every call with nothing logged. Since this is a published package, the pipeline now inspects the retriever's signature once, caches the result, and passes the keyword only when it is actually accepted. A retriever taking `**kwargs` counts as accepting it. Verified the inspection runs exactly once for a pipeline's lifetime, including under the parallel executor.

This is capability detection, not a name check — the pipeline still knows nothing about which retriever it holds, which is the point of #53.

**Bug discovered while doing this work, filed separately:**

- #256 [BUG] pipeline: every retrieval failure is silently swallowed, so a broken retriever is indistinguishable from an empty result

That one is pre-existing (`pipeline.py:177` on `main`) and this PR does not change it — it only narrows what can raise inside the `try`. It is the reason the compatibility hazard above was worth handling rather than documenting: with the swallow in place, the failure mode is invisible. Happy to send the logging fix as a follow-up; #256 has the detail.

**Known limitation, disclosed:** if a retriever's `retrieve` is decorator-wrapped such that `inspect.signature` reports `**kwargs` while the underlying function does not accept the keyword, it will still raise into that same handler. And a callable whose signature cannot be introspected at all is treated as not supporting the parameter — safe, but currently silent. Both are noted in #256.

If you'd rather not carry the introspection and prefer to declare the new parameter simply required of all retrievers, that is a reasonable call for a pre-1.0 package and I'll strip it — your repo, your compatibility policy.

Generated by Claude Opus 5 (brief, review), Kimi K2.7 Code (implementation), Claude Sonnet 5 (verification)
