### PR TITLE
fix(config): export the missing config models, and stop leaking the API key

### DIFF
--- a/openagent_eval/config/__init__.py
+++ b/openagent_eval/config/__init__.py
@@ -3,19 +3,25 @@
 from openagent_eval.config.loader import load_config
 from openagent_eval.config.models import (
     Config,
+    CorpusConfig,
     DatasetConfig,
     EmbedderConfig,
     LLMConfig,
     MetricsConfig,
+    OutputFormat,
+    ReportConfig,
     RetrieverConfig,
 )
 
 __all__ = [
     "Config",
+    "CorpusConfig",
     "DatasetConfig",
     "EmbedderConfig",
     "LLMConfig",
     "MetricsConfig",
+    "OutputFormat",
+    "ReportConfig",
     "RetrieverConfig",
     "load_config",
 ]

--- a/openagent_eval/config/models.py
+++ b/openagent_eval/config/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, SecretStr, field_validator
 
 
 class OutputFormat(str, Enum):
@@ -22,13 +22,15 @@ class LLMConfig(BaseModel):
 
     provider: str = Field(..., description="LLM provider name (e.g., openai, gemini, anthropic)")
     model: str = Field(..., description="Model identifier (e.g., gpt-4o)")
-    api_key: str | None = Field(None, description="API key (can use environment variable)")
+    api_key: SecretStr | None = Field(
+        None, description="API key (can use environment variable)"
+    )
     temperature: float = Field(0.0, ge=0.0, le=2.0, description="Temperature for generation")
     max_tokens: int | None = Field(None, ge=1, description="Maximum tokens to generate")
 
     @field_validator("api_key")
     @classmethod
-    def validate_api_key(cls, v: str | None) -> str | None:
+    def validate_api_key(cls, v: SecretStr | None) -> SecretStr | None:
         """Validate API key format."""
         if v is not None and len(v) < 10:
             raise ValueError("API key appears to be invalid (too short)")

--- a/openagent_eval/config/validator.py
+++ b/openagent_eval/config/validator.py
@@ -82,7 +82,12 @@ def validate_api_keys(config: Config) -> list[str]:
     provider = config.llm.provider.lower()
     if provider in provider_env_map:
         env_var = provider_env_map[provider]
-        if not config.llm.api_key and not os.environ.get(env_var):
+        resolved_key = (
+            config.llm.api_key.get_secret_value()
+            if config.llm.api_key is not None
+            else None
+        )
+        if not resolved_key and not os.environ.get(env_var):
             missing_keys.append(env_var)
 
     return missing_keys

--- a/openagent_eval/providers/llm/anthropic.py
+++ b/openagent_eval/providers/llm/anthropic.py
@@ -99,7 +99,12 @@ class Anthropic(LLMProvider):
                 in environment.
         """
         if config is not None:
-            api_key = api_key or getattr(config, "api_key", None)
+            config_api_key = getattr(config, "api_key", None)
+            api_key = api_key or (
+                config_api_key.get_secret_value()
+                if config_api_key is not None
+                else None
+            )
             model = getattr(config, "model", model) or model
             temperature = (
                 getattr(config, "temperature", temperature)

--- a/openagent_eval/providers/llm/gemini.py
+++ b/openagent_eval/providers/llm/gemini.py
@@ -107,7 +107,12 @@ class Gemini(LLMProvider):
                 GEMINI_API_KEY environment variable is not set.
         """
         if config is not None:
-            api_key = api_key or getattr(config, "api_key", None)
+            config_api_key = getattr(config, "api_key", None)
+            api_key = api_key or (
+                config_api_key.get_secret_value()
+                if config_api_key is not None
+                else None
+            )
             model = getattr(config, "model", model) or model
             temperature = (
                 getattr(config, "temperature", temperature)

--- a/openagent_eval/providers/llm/groq.py
+++ b/openagent_eval/providers/llm/groq.py
@@ -102,7 +102,16 @@ class Groq(LLMProvider):
         """
         # Extract from config if provided
         if config is not None:
-            api_key = api_key or getattr(config, "api_key", None) or os.environ.get("GROQ_API_KEY")
+            config_api_key = getattr(config, "api_key", None)
+            api_key = (
+                api_key
+                or (
+                    config_api_key.get_secret_value()
+                    if config_api_key is not None
+                    else None
+                )
+                or os.environ.get("GROQ_API_KEY")
+            )
             model = getattr(config, "model", model) or model
             temperature = getattr(config, "temperature", temperature) if getattr(config, "temperature", None) is not None else temperature
             max_tokens = getattr(config, "max_tokens", max_tokens) if getattr(config, "max_tokens", None) is not None else max_tokens

--- a/openagent_eval/providers/llm/openai.py
+++ b/openagent_eval/providers/llm/openai.py
@@ -108,7 +108,11 @@ class OpenAIProvider(LLMProvider):
             ProviderConnectionError: If API key is not found or invalid.
         """
         if config:
-            self._api_key = config.api_key or os.getenv("OPENAI_API_KEY")
+            self._api_key = (
+                config.api_key.get_secret_value()
+                if config.api_key is not None
+                else os.getenv("OPENAI_API_KEY")
+            )
             self._model = config.model
             self._temperature = config.temperature
             self._max_tokens = config.max_tokens

--- a/openagent_eval/providers/llm/openrouter.py
+++ b/openagent_eval/providers/llm/openrouter.py
@@ -95,7 +95,12 @@ class OpenRouter(LLMProvider):
             ProviderConnectionError: If API key is not provided or found in environment.
         """
         if config is not None:
-            api_key = api_key or getattr(config, "api_key", None)
+            config_api_key = getattr(config, "api_key", None)
+            api_key = api_key or (
+                config_api_key.get_secret_value()
+                if config_api_key is not None
+                else None
+            )
             model = getattr(config, "model", model) or model
             temperature = (
                 getattr(config, "temperature", temperature)

--- a/tests/unit/test_config/test_exports.py
+++ b/tests/unit/test_config/test_exports.py
@@ -1,0 +1,41 @@
+"""Tests for the public import surface of ``openagent_eval.config``.
+
+Regression guard for #47: config model names must be importable directly from
+``openagent_eval.config`` and must be listed in ``__all__``.
+"""
+
+from __future__ import annotations
+
+import openagent_eval.config as config_pkg
+from openagent_eval.config.models import CorpusConfig as ModelsCorpusConfig
+from openagent_eval.config.models import OutputFormat as ModelsOutputFormat
+from openagent_eval.config.models import ReportConfig as ModelsReportConfig
+
+
+def test_all_lists_the_full_public_surface() -> None:
+    """``__all__`` must enumerate exactly the intended public names."""
+    assert set(config_pkg.__all__) == {
+        "Config",
+        "CorpusConfig",
+        "DatasetConfig",
+        "EmbedderConfig",
+        "LLMConfig",
+        "MetricsConfig",
+        "OutputFormat",
+        "ReportConfig",
+        "RetrieverConfig",
+        "load_config",
+    }
+
+
+def test_exported_names_match_defining_objects() -> None:
+    """Re-exported names must be the same objects as the defining module."""
+    assert config_pkg.CorpusConfig is ModelsCorpusConfig
+    assert config_pkg.OutputFormat is ModelsOutputFormat
+    assert config_pkg.ReportConfig is ModelsReportConfig
+
+
+def test_exported_names_are_in_all() -> None:
+    """Each newly exported name must be present in ``__all__``."""
+    for name in ("CorpusConfig", "OutputFormat", "ReportConfig"):
+        assert name in config_pkg.__all__, f"{name} missing from __all__"

--- a/tests/unit/test_config/test_models.py
+++ b/tests/unit/test_config/test_models.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pydantic import SecretStr
 
 from openagent_eval.config.loader import load_config
 from openagent_eval.config.models import (
@@ -50,6 +51,29 @@ class TestConfigModels:
         # Invalid API key (too short)
         with pytest.raises(Exception):
             LLMConfig(provider="openai", model="gpt-4o", api_key="short")
+
+    def test_llm_config_api_key_is_secretstr(self) -> None:
+        """LLMConfig.api_key is stored as a Pydantic SecretStr."""
+        secret = "sk-live-key-1234567890"
+        config = LLMConfig(provider="openai", model="gpt-4o", api_key=secret)
+        assert isinstance(config.api_key, SecretStr)
+        assert config.api_key.get_secret_value() == secret
+
+    def test_llm_config_api_key_not_in_repr(self) -> None:
+        """The API key must not leak through repr() or str()."""
+        secret = "sk-live-key-1234567890"
+        config = LLMConfig(provider="openai", model="gpt-4o", api_key=secret)
+        rendered = repr(config)
+        assert secret not in rendered
+        assert "**********" in rendered
+        assert secret not in str(config)
+
+    def test_llm_config_api_key_round_trip(self) -> None:
+        """.get_secret_value() returns the original key unchanged."""
+        secret = "sk-round-trip-1234567890"
+        config = LLMConfig(provider="openai", model="gpt-4o", api_key=secret)
+        assert config.api_key is not None
+        assert config.api_key.get_secret_value() == secret
 
     def test_retriever_config(self) -> None:
         """Test RetrieverConfig creation."""


### PR DESCRIPTION
## Description

Two config-package fixes.

`CorpusConfig`, `ReportConfig` and `OutputFormat` were defined in `config/models.py` but never exported, so `from openagent_eval.config import CorpusConfig` raised ImportError despite `CorpusConfig` backing the `audit` command.

`LLMConfig.api_key` was a plain `str`, so the key appeared in `repr()`, `str()` and model dumps. It is now `SecretStr`, with every in-repo consumer reading it through `.get_secret_value()`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] CI/CD update

Both boxes are ticked deliberately — see Additional Notes. The `api_key` type change is breaking for external code that reads the field.

## Related Issues

Closes #47
Closes #46

## How Has This Been Tested?

New tests in `tests/unit/test_config/test_exports.py` and `tests/unit/test_config/test_models.py`, each verified to fail on the code it targets:

- Exports, with `config/__init__.py` reverted to `main`: `AttributeError: module 'openagent_eval.config' has no attribute 'CorpusConfig'`, plus `CorpusConfig missing from __all__`. Restored: 3 passed.
- SecretStr, with `config/models.py` reverted to `main`: `assert False = isinstance('sk-live-key-1234567890', SecretStr)`, `assert 'sk-live-key-1234567890' not in "LLMConfig(...api_key='sk-live-key-1234567890'...)"`, and `AttributeError: 'str' object has no attribute 'get_secret_value'`. Restored: 21 passed.

Also checked by hand that the secret is absent from `repr()`, `str()` and `model_dump_json()` on both a bare `LLMConfig` and one nested in a full `Config`, and that `.get_secret_value()` returns the original string exactly.

- [x] Unit tests pass (`uv run pytest`) — 1029 passed, 5 skipped, coverage 79.20% against the 75% floor. The 5 skips are pre-existing environment gaps (rank-bm25 / chromadb absent, DeepEval- and OpenAI-gated tests), unrelated to this diff.
- [ ] Linter passes (`uv run ruff check .`) — exits 1 on pre-existing findings. On the touched files specifically, base and branch produce the identical 8 findings (UP037 ×3, TC001, F841 ×2, TC003, B017) at the same logical locations, differing only in line numbers. Zero new findings.
- [ ] Type checker passes (`uv run mypy openagent_eval/`) — not run; CI's step targets a non-existent `src/`, which is #250.
- [x] Manual testing performed — as described above.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — nothing here needed explaining
- [ ] I have made corresponding changes to the documentation — flagged in Additional Notes as worth your call
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**This closes a real leak, not just a noisy `repr()`.** `reports/manager.py` persists reports with `json.dumps(report.config.model_dump(), ..., default=str)`. With `api_key` as a plain `str`, the raw key was serialised verbatim into every saved evaluation report on disk. With `SecretStr`, `default=str` renders `**********`, because `str(SecretStr(...))` is already masked. Worth a sanity-check from you, though: that site masks by happy accident of the `default=str` fallback rather than by an explicit `.get_secret_value()` call, and no regression test pins it. If you'd like, I'll add a test that asserts a persisted report never contains the raw key.

**The breaking part, stated plainly.** Anything outside this repo doing `config.llm.api_key` and expecting a `str` now gets a `SecretStr` and must call `.get_secret_value()`. Construction is unaffected — `LLMConfig(api_key="sk-...")` still works, Pydantic coerces. Inside the repo I checked every reader: `config/validator.py`, and the anthropic, gemini, groq, openai and openrouter providers, all now guarded by a `None` check before `.get_secret_value()`. `ollama.py` and `mock.py` never read it. The embedder and vector-store providers take their own unrelated `api_key` constructor arguments and are untouched. If this belongs in a release note or a migration line in the docs, tell me where and I'll add it.

**Not done, deliberately.** #46 also proposes a validator rejecting keys under 10 characters. That check already exists on `main`; this PR only re-types the validator's signature and adds no new rule, since tightening key validation is a separate behavioural decision that would break short test keys.

Generated by Claude Opus 5 (brief, review), Kimi K2.7 Code (implementation), Claude Sonnet 5 (verification)
