### PR TITLE
fix(cicd): populate metrics_summary so oaeval test can evaluate thresholds

### DIFF
--- a/openagent_eval/cicd/plugin.py
+++ b/openagent_eval/cicd/plugin.py
@@ -227,9 +227,13 @@ class OAEvalPlugin:
         # Evaluate thresholds
         evaluator = ThresholdEvaluator(cicd_config)
         eval_result = evaluator.evaluate_all_gates(flat_metrics)
-        # Carry the metrics in the same shape the engine summary produces so
-        # downstream consumers (e.g. the `oaeval test` threshold path) can
-        # evaluate gates against them.
+        # Expose the plugin's threshold-target mapping so downstream
+        # consumers (e.g. the `oaeval test` threshold path) can evaluate
+        # gates against it. This is the engine's metric set plus the
+        # execution counts (total_items, successful_evaluations,
+        # failed_evaluations) that the plugin already supports as gate
+        # targets, so it is a superset of the engine summary's own
+        # `metrics_summary`, not the same set.
         eval_result.summary["metrics_summary"] = flat_metrics
         eval_result.summary["duration_seconds"] = duration
 

--- a/openagent_eval/cicd/plugin.py
+++ b/openagent_eval/cicd/plugin.py
@@ -227,6 +227,10 @@ class OAEvalPlugin:
         # Evaluate thresholds
         evaluator = ThresholdEvaluator(cicd_config)
         eval_result = evaluator.evaluate_all_gates(flat_metrics)
+        # Carry the metrics in the same shape the engine summary produces so
+        # downstream consumers (e.g. the `oaeval test` threshold path) can
+        # evaluate gates against them.
+        eval_result.summary["metrics_summary"] = flat_metrics
         eval_result.summary["duration_seconds"] = duration
 
         return eval_result

--- a/openagent_eval/cicd/plugin.py
+++ b/openagent_eval/cicd/plugin.py
@@ -175,18 +175,29 @@ class OAEvalPlugin:
 
             dataset_items = load_dataset_for_run(eval_config)
 
-            # Run async evaluation
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                # If we're already in an async context, create a new task
+            # Run async evaluation. Use get_running_loop() instead of
+            # get_event_loop(): after any completed asyncio.run() in the
+            # process, the event-loop policy holds no current loop
+            # (asyncio.run calls set_event_loop(None) on completion), so
+            # get_event_loop() raises RuntimeError before is_running() is
+            # ever reached — and the broad `except Exception` below then
+            # swallowed it into an error summary (issue #261).
+            # get_running_loop() only asks whether a loop is running right
+            # now, independent of the policy's current-loop state.
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                # No loop is running: the normal synchronous case.
+                result = asyncio.run(engine.run(dataset_items))
+            else:
+                # We're already inside a live async context; offload to a
+                # thread and run it there, preserving the timeout.
                 import concurrent.futures
 
                 with concurrent.futures.ThreadPoolExecutor() as pool:
                     result = pool.submit(
                         asyncio.run, engine.run(dataset_items)
                     ).result(timeout=timeout)
-            else:
-                result = loop.run_until_complete(engine.run(dataset_items))
 
             # Extract metrics from summary
             metrics = result.summary.get("metrics_summary", {})

--- a/tests/unit/test_cicd/test_cli_test.py
+++ b/tests/unit/test_cicd/test_cli_test.py
@@ -1,5 +1,6 @@
 """Unit tests for CLI test command."""
 
+import json
 import re
 
 from typer.testing import CliRunner
@@ -77,3 +78,59 @@ class TestTestCommand:
         output = _strip_ansi(result.output)
         assert "threshold" in output.lower()
         assert "-t" in output
+
+    def test_test_command_passing_threshold_is_not_reported_missing(self, tmp_path):
+        """Regression test for issue #228.
+
+        A threshold that should pass must not fail with "metric not found":
+        the gate summary returned by ``OAEvalPlugin.run_evaluation`` must
+        carry ``metrics_summary`` so the CLI threshold-evaluation path can
+        look the metric up. Uses fully offline mock providers.
+        """
+        dataset_path = tmp_path / "data.json"
+        dataset_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "question": "What is RAG?",
+                        "ground_truth": "RAG combines retrieval with generation.",
+                        "context": "RAG combines retrieval with generation.",
+                        "ground_truth_contexts": [
+                            "RAG combines retrieval with generation."
+                        ],
+                    }
+                ]
+            )
+        )
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            f"""
+dataset:
+  path: {dataset_path}
+llm:
+  provider: mock
+  model: mock-model
+retriever:
+  provider: mock
+  settings:
+    collection_name: c
+metrics:
+  retrieval: []
+  generation: ["exact_match"]
+  performance: []
+  cost: []
+report:
+  output: json
+  output_dir: {tmp_path / "reports_out"}
+parallel: false
+"""
+        )
+
+        result = runner.invoke(
+            app,
+            ["test", str(config_path), "-t", "exact_match:gte:0.5"],
+        )
+        output = _strip_ansi(result.output)
+
+        assert "not found in results" not in output
+        assert result.exit_code == 0, output

--- a/tests/unit/test_cicd/test_cli_test.py
+++ b/tests/unit/test_cicd/test_cli_test.py
@@ -16,6 +16,53 @@ def _strip_ansi(text: str) -> str:
     return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 
+def _write_offline_config(tmp_path):
+    """Write a fully offline dataset + config for CLI test runs.
+
+    The mock providers echo ``ground_truth``, so ``exact_match`` scores
+    exactly 1.0. Returns the config path.
+    """
+    dataset_path = tmp_path / "data.json"
+    dataset_path.write_text(
+        json.dumps(
+            [
+                {
+                    "question": "What is RAG?",
+                    "ground_truth": "RAG combines retrieval with generation.",
+                    "context": "RAG combines retrieval with generation.",
+                    "ground_truth_contexts": [
+                        "RAG combines retrieval with generation."
+                    ],
+                }
+            ]
+        )
+    )
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        f"""
+dataset:
+  path: {dataset_path}
+llm:
+  provider: mock
+  model: mock-model
+retriever:
+  provider: mock
+  settings:
+    collection_name: c
+metrics:
+  retrieval: []
+  generation: ["exact_match"]
+  performance: []
+  cost: []
+report:
+  output: json
+  output_dir: {tmp_path / "reports_out"}
+parallel: false
+"""
+    )
+    return config_path
+
+
 class TestTestCommand:
     """Tests for oaeval test command."""
 
@@ -85,46 +132,14 @@ class TestTestCommand:
         A threshold that should pass must not fail with "metric not found":
         the gate summary returned by ``OAEvalPlugin.run_evaluation`` must
         carry ``metrics_summary`` so the CLI threshold-evaluation path can
-        look the metric up. Uses fully offline mock providers.
+        look the metric up. Uses fully offline mock providers (the mock
+        echoes ``ground_truth``, so ``exact_match`` scores exactly 1.0).
+
+        Also asserts the positive behaviour: the threshold was actually
+        evaluated against the real computed value, not silently waved
+        through.
         """
-        dataset_path = tmp_path / "data.json"
-        dataset_path.write_text(
-            json.dumps(
-                [
-                    {
-                        "question": "What is RAG?",
-                        "ground_truth": "RAG combines retrieval with generation.",
-                        "context": "RAG combines retrieval with generation.",
-                        "ground_truth_contexts": [
-                            "RAG combines retrieval with generation."
-                        ],
-                    }
-                ]
-            )
-        )
-        config_path = tmp_path / "config.yaml"
-        config_path.write_text(
-            f"""
-dataset:
-  path: {dataset_path}
-llm:
-  provider: mock
-  model: mock-model
-retriever:
-  provider: mock
-  settings:
-    collection_name: c
-metrics:
-  retrieval: []
-  generation: ["exact_match"]
-  performance: []
-  cost: []
-report:
-  output: json
-  output_dir: {tmp_path / "reports_out"}
-parallel: false
-"""
-        )
+        config_path = _write_offline_config(tmp_path)
 
         result = runner.invoke(
             app,
@@ -133,4 +148,32 @@ parallel: false
         output = _strip_ansi(result.output)
 
         assert "not found in results" not in output
+        # The threshold must be evaluated against the real value (1.0),
+        # and the gate must be reported as passing.
+        assert "exact_match: 1.0000 gte 0.5000" in output, output
+        assert "PASS" in output, output
         assert result.exit_code == 0, output
+
+    def test_test_command_failing_threshold_is_enforced(self, tmp_path):
+        """Complement to the #228 regression test.
+
+        A threshold that genuinely cannot be met (``exact_match`` scores
+        exactly 1.0 with the offline mock providers, so ``gte:1.5`` must
+        fail) must exit non-zero and report the failure with the real
+        actual value. This catches an implementation that auto-passes or
+        skips missing/unresolvable metrics: a suite that only checks the
+        passing direction cannot notice that enforcement stopped.
+        """
+        config_path = _write_offline_config(tmp_path)
+
+        result = runner.invoke(
+            app,
+            ["test", str(config_path), "-t", "exact_match:gte:1.5"],
+        )
+        output = _strip_ansi(result.output)
+
+        # The metric must resolve (not "not found") and the failure must
+        # be reported against the real computed value (1.0).
+        assert "not found in results" not in output
+        assert "exact_match: 1.0000 NOT gte 1.5000" in output, output
+        assert result.exit_code == 1, output

--- a/tests/unit/test_cicd/test_cli_test.py
+++ b/tests/unit/test_cicd/test_cli_test.py
@@ -1,5 +1,6 @@
 """Unit tests for CLI test command."""
 
+import asyncio
 import json
 import re
 
@@ -177,3 +178,32 @@ class TestTestCommand:
         assert "not found in results" not in output
         assert "exact_match: 1.0000 NOT gte 1.5000" in output, output
         assert result.exit_code == 1, output
+
+    def test_test_command_after_completed_asyncio_run(self, tmp_path):
+        """Regression test for issue #261.
+
+        ``asyncio.run()`` calls ``asyncio.set_event_loop(None)`` when it
+        completes, so afterwards ``asyncio.get_event_loop()`` in the main
+        thread raises ``RuntimeError`` instead of auto-creating a loop.
+        ``run_evaluation`` must not depend on that policy state: after a
+        completed ``asyncio.run`` in the same process, the evaluation must
+        still actually run and the threshold must be evaluated against the
+        real metrics — not swallowed into an ``error`` summary that the
+        CLI then reports as "not found in results".
+        """
+        asyncio.run(asyncio.sleep(0))
+
+        config_path = _write_offline_config(tmp_path)
+
+        result = runner.invoke(
+            app,
+            ["test", str(config_path), "-t", "exact_match:gte:0.5"],
+        )
+        output = _strip_ansi(result.output)
+
+        assert "not found in results" not in output
+        # The evaluation must have actually run: the threshold is
+        # evaluated against the real computed value (1.0) and passes.
+        assert "exact_match: 1.0000 gte 0.5000" in output, output
+        assert "PASS" in output, output
+        assert result.exit_code == 0, output


### PR DESCRIPTION
## Description

`oaeval test` fails for every threshold regardless of the actual scores, because the gate summary it reads carries no `metrics_summary`. `OAEvalPlugin.run_evaluation` returns the `EvaluationResult` built by `ThresholdEvaluator.evaluate_all_gates`, whose summary holds only gate/threshold counts, so `cli/commands/test.py` looks up `metrics_summary`, gets `{}`, and every threshold resolves to `actual=None` → `Metric '<name>' not found in results`.

This populates `metrics_summary` in the summary the plugin returns, so the CLI's threshold evaluation sees the same metric values the plugin evaluated its own gates against. `ThresholdEvaluator` is unchanged.

It also fixes a second defect in the same function, which the regression tests for the first one uncovered — see "Why this PR contains two fixes" below.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] CI/CD update

## Related Issues

Closes #228
Closes #261

## How Has This Been Tested?

Reproduced first on unmodified `main` (`b00ab48`) with a fully offline config using the in-repo mock providers, which echo `ground_truth` so `exact_match` scores `1.0` and a `gte:0.5` threshold must pass:

```
$ oaeval test config.yaml -t exact_match:gte:0.5 --json
...
"actual": null,
"message": "Metric 'exact_match' not found in results"
$ echo $?
1
```

`oaeval run` on the same config exits 0 and reports `exact_match: 1.0`, confirming the metric is computed and the threshold genuinely ought to pass. After the fix the same command exits 0 with `"status": "passed"` and `"actual": 1.0`.

Three regression tests were added, all driving the real `oaeval test` command end to end via `CliRunner`:

- a should-pass case asserting the actual comparison (`exact_match: 1.0000 gte 0.5000`) and a passing gate row — not merely the absence of the error string;
- a should-fail case (`exact_match:gte:1.5`) asserting exit code 1 and `exact_match: 1.0000 NOT gte 1.5000`;
- a case that completes an `asyncio.run(...)` first and then asserts the evaluation still runs (the #261 regression).

The first two were checked against a deliberately broken implementation in which missing metrics are treated as passing — that variant waves even `gte:1.5` through as passed, and both tests fail on it, so the pair detects enforcement being silently skipped rather than only detecting the original symptom. Each test was also confirmed to fail with its corresponding source change reverted.

- [x] Unit tests pass (`uv run pytest tests/unit -v --tb=short` → 1011 passed, 4 skipped; the 4 skips are pre-existing environment skips for `chromadb` and `OPENAI_API_KEY`)
- [x] Whole suite with coverage, matching the CI `Coverage` job (`uv run pytest --cov=openagent_eval --cov-report=term-missing --cov-fail-under=75` → 1065 passed, 4 skipped, 81.08%)
- [ ] Linter passes (`uv run ruff check .`) — see note below
- [ ] Type checker passes (`uv run mypy openagent_eval/`) — see note below
- [x] Manual testing performed (the before/after run above)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Why this PR contains two fixes.** The `metrics_summary` fix alone is not observable in any process that has already completed an `asyncio.run(...)`, and I only found that out because the new regression tests passed in isolation and failed when the whole suite ran in one process. The cause is separate and is filed as #261: `run_evaluation` called `asyncio.get_event_loop()`, but `asyncio.run` sets the current loop to `None` when it finishes, so that call raises `RuntimeError` before the `if loop.is_running()` test is reached, and the broad `except Exception` converts it into a returned result with an `error` key — which the CLI then reports as "metric not found", i.e. indistinguishable from the bug being fixed here. The fix uses `asyncio.get_running_loop()` instead, so the behaviour no longer depends on the event-loop policy's current-loop state; the existing thread-pool offload and its `timeout` are unchanged for the case where a loop really is running.

I kept them together because the first fix is not demonstrably correct without the second, and separating them would mean landing a regression test that fails in your own CI. **Happy to split it into two PRs if you would rather review them independently** — say the word and I will.

**On the two unchecked test boxes.** `ruff check .` exits 1 on pre-existing findings at `main` itself, so I could not honestly tick that box for this branch and did not want to imply otherwise. Instead I compared per-file, at `main` and on this branch, for the two files this PR touches: identical results on both sides (`UP035` and `B904` in `plugin.py`, `I001` in the test file, plus pre-existing format drift), so this diff adds no new findings. I have deliberately not reformatted or fixed those pre-existing findings, since that would bury a small behavioural fix in unrelated churn — happy to send that separately if you want it. The `mypy` box is unticked for the same reason: it is not clean at `main`, and this diff does not change that either way.

No documentation changes seemed warranted, as this restores the documented behaviour of existing functionality rather than changing it — say the word if you would like the CI/CD docs to call it out.

**One thing worth your judgement.** The mapping I store in `metrics_summary` is the plugin's threshold-target mapping, which is the engine's metric set *plus* the three execution counts the plugin already supports as gate targets (`total_items`, `successful_evaluations`, `failed_evaluations`). It is therefore a superset of what the engine puts in its own `metrics_summary`, and the code comment says so explicitly rather than claiming parity. I chose the superset deliberately: narrowing it to metrics only would make `oaeval test -t total_items:gte:1` report "metric not found", which is the same class of failure this PR fixes. The tradeoff is that a consumer iterating `metrics_summary` as metric-name → value would now also see those three counts. Nothing in the repo does that with a plugin result today, but if you would rather keep the two summaries schema-identical, narrowing it is a one-line change — your call.

Generated by Claude Opus 5 (brief, review), Kimi K3 (implementation)