### PR TITLE
fix(pipeline): log retrieval failures so a broken retriever is distinguishable from an empty one

### DIFF
--- a/openagent_eval/core/pipeline.py
+++ b/openagent_eval/core/pipeline.py
@@ -117,7 +117,7 @@ class Pipeline:
 
         try:
             # 1. Retrieval
-            contexts = await self._retrieve(question, context, gt_contexts, item, result)
+            contexts = await self._retrieve(question, context, gt_contexts)
 
             # 2. Generation
             answer, token_usage, latency_ms = await self._generate(
@@ -223,8 +223,6 @@ class Pipeline:
         question: str,
         context: str | None,
         gt_contexts: list[str],
-        item: dict[str, Any],
-        result: PipelineResult,
     ) -> list[str]:
         """Retrieve contexts for a question, or fall back to dataset context.
 

--- a/openagent_eval/core/pipeline.py
+++ b/openagent_eval/core/pipeline.py
@@ -228,9 +228,13 @@ class Pipeline:
     ) -> list[str]:
         """Retrieve contexts for a question, or fall back to dataset context.
 
-        A retrieval failure is logged and recorded in ``result.errors`` so a
-        broken retriever is distinguishable from a clean empty retrieval; the
-        fallback behaviour itself is unchanged.
+        A retrieval failure is logged (log-only) so a broken retriever is
+        distinguishable from a clean empty retrieval; the fallback behaviour
+        itself is unchanged. The failure is deliberately NOT recorded in
+        ``result.errors``: engine.py derives ``successful_evaluations`` from
+        ``len(results) - len(errors)``, and an entry here has no paired
+        placeholder result, so recording it would mis-count a healthy run
+        as failed.
         """
         if self._retriever is not None:
             try:
@@ -249,13 +253,6 @@ class Pipeline:
                     question,
                     type(e).__name__,
                     e,
-                )
-                result.errors.append(
-                    {
-                        "item": {k: v for k, v in item.items() if k != "metadata"},
-                        "error": str(e),
-                        "error_type": type(e).__name__,
-                    }
                 )
                 if context:
                     return [context]

--- a/openagent_eval/core/pipeline.py
+++ b/openagent_eval/core/pipeline.py
@@ -12,11 +12,14 @@ registry. Each item is evaluated independently so the loop can run in parallel.
 from __future__ import annotations
 
 import inspect
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
 from openagent_eval.config.models import Config
 from openagent_eval.metrics.base import BaseMetric
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -114,7 +117,7 @@ class Pipeline:
 
         try:
             # 1. Retrieval
-            contexts = await self._retrieve(question, context, gt_contexts)
+            contexts = await self._retrieve(question, context, gt_contexts, item, result)
 
             # 2. Generation
             answer, token_usage, latency_ms = await self._generate(
@@ -193,7 +196,14 @@ class Pipeline:
 
         try:
             sig = inspect.signature(retrieve_method)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError) as e:
+            logger.warning(
+                "Could not inspect signature of %r (%s: %s); "
+                "assuming no ground_truth_contexts support",
+                retrieve_method,
+                type(e).__name__,
+                e,
+            )
             self._retriever_supports_ground_truth_contexts = False
             return False
 
@@ -209,9 +219,19 @@ class Pipeline:
         return False
 
     async def _retrieve(
-        self, question: str, context: str | None, gt_contexts: list[str]
+        self,
+        question: str,
+        context: str | None,
+        gt_contexts: list[str],
+        item: dict[str, Any],
+        result: PipelineResult,
     ) -> list[str]:
-        """Retrieve contexts for a question, or fall back to dataset context."""
+        """Retrieve contexts for a question, or fall back to dataset context.
+
+        A retrieval failure is logged and recorded in ``result.errors`` so a
+        broken retriever is distinguishable from a clean empty retrieval; the
+        fallback behaviour itself is unchanged.
+        """
         if self._retriever is not None:
             try:
                 if self._supports_ground_truth_contexts():
@@ -221,8 +241,22 @@ class Pipeline:
                 else:
                     docs = await self._retriever.retrieve(question, k=self._k)
                 return [doc.content for doc in docs]
-            except Exception:
+            except Exception as e:
                 # Retrieval failure -> fall back to any dataset-provided context.
+                logger.warning(
+                    "Retrieval failed for question %r (%s: %s); "
+                    "falling back to dataset-provided context",
+                    question,
+                    type(e).__name__,
+                    e,
+                )
+                result.errors.append(
+                    {
+                        "item": {k: v for k, v in item.items() if k != "metadata"},
+                        "error": str(e),
+                        "error_type": type(e).__name__,
+                    }
+                )
                 if context:
                     return [context]
                 return []

--- a/tests/unit/test_core/test_pipeline_retrieval_failure_visibility.py
+++ b/tests/unit/test_core/test_pipeline_retrieval_failure_visibility.py
@@ -2,8 +2,11 @@
 
 Verifies that a retriever failure inside ``Pipeline._retrieve`` is no longer
 silently swallowed: the dataset-context fallback still applies (behaviour
-unchanged), but the failure is now logged naming the exception and recorded
-in the run's ``errors`` in the same shape as the other failure modes.
+unchanged), and the failure is logged naming the exception. The degradation
+is log-only: it must NOT be recorded in the run's ``errors``, because
+engine.py computes ``successful_evaluations`` as ``len(results) -
+len(errors)`` and an entry without a paired placeholder result would
+mis-count a healthy run as failed (breaking cicd gate metrics).
 """
 
 from __future__ import annotations
@@ -48,7 +51,7 @@ class _FailingRetriever(Retriever):
 async def test_retrieval_failure_is_visible_and_still_falls_back(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A raising retriever degrades to dataset context but is surfaced."""
+    """A raising retriever degrades to dataset context and is logged only."""
     from openagent_eval.providers.llm.mock import MockLLMProvider
 
     config = Config(
@@ -78,13 +81,14 @@ async def test_retrieval_failure_is_visible_and_still_falls_back(
     # (a) Fallback behaviour is unchanged: the dataset context is still used.
     assert result.results[0].contexts == ["dataset-provided context"]
 
-    # (b) The failure is recorded in the run's errors, in the same shape the
-    # other failure modes use (item / error / error_type).
-    assert len(result.errors) == 1
-    entry = result.errors[0]
-    assert entry["error_type"] == "RuntimeError"
-    assert "vector store unreachable" in entry["error"]
-    assert entry["item"]["question"] == "What is RAG?"
+    # (b) The degradation is log-only: it must NOT appear in result.errors.
+    # engine.py computes successful_evaluations as
+    # len(results) - len(errors), so an errors entry without a paired
+    # placeholder result would mis-count this healthy run as failed and
+    # trip cicd gate metrics. This pins that property.
+    assert result.errors == []
+    assert len(result.results) == 1
+    assert len(result.results) - len(result.errors) == 1
 
     # (c) The failure is logged, naming the exception.
     assert "RuntimeError" in caplog.text

--- a/tests/unit/test_core/test_pipeline_retrieval_failure_visibility.py
+++ b/tests/unit/test_core/test_pipeline_retrieval_failure_visibility.py
@@ -1,0 +1,91 @@
+"""Regression test for issue #256.
+
+Verifies that a retriever failure inside ``Pipeline._retrieve`` is no longer
+silently swallowed: the dataset-context fallback still applies (behaviour
+unchanged), but the failure is now logged naming the exception and recorded
+in the run's ``errors`` in the same shape as the other failure modes.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pytest
+
+from openagent_eval.config.models import (
+    Config,
+    DatasetConfig,
+    LLMConfig,
+    MetricsConfig,
+    ReportConfig,
+    RetrieverConfig,
+)
+from openagent_eval.core.pipeline import Pipeline
+from openagent_eval.providers.base.retriever import Retriever
+
+if TYPE_CHECKING:
+    from openagent_eval.providers.models import Document
+
+
+class _FailingRetriever(Retriever):
+    """Retriever whose ``retrieve`` always raises, simulating a broken backend."""
+
+    name = "failing"
+    description = "Always raises from retrieve()"
+
+    async def retrieve(
+        self,
+        query: str,
+        k: int = 5,
+        *,
+        ground_truth_contexts: list[str] | None = None,
+    ) -> list[Document]:
+        raise RuntimeError("vector store unreachable")
+
+
+@pytest.mark.asyncio
+async def test_retrieval_failure_is_visible_and_still_falls_back(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A raising retriever degrades to dataset context but is surfaced."""
+    from openagent_eval.providers.llm.mock import MockLLMProvider
+
+    config = Config(
+        dataset=DatasetConfig(path="data/questions.json"),
+        llm=LLMConfig(provider="mock", model="mock-model"),
+        retriever=RetrieverConfig(provider="failing"),
+        metrics=MetricsConfig(),
+        report=ReportConfig(),
+        parallel=False,
+    )
+
+    pipeline = Pipeline(
+        config, retriever=_FailingRetriever(), llm=MockLLMProvider()
+    )
+
+    with caplog.at_level(logging.WARNING, logger="openagent_eval.core.pipeline"):
+        result = await pipeline.execute(
+            [
+                {
+                    "question": "What is RAG?",
+                    "ground_truth": "RAG is retrieval augmented generation.",
+                    "context": "dataset-provided context",
+                }
+            ]
+        )
+
+    # (a) Fallback behaviour is unchanged: the dataset context is still used.
+    assert result.results[0].contexts == ["dataset-provided context"]
+
+    # (b) The failure is recorded in the run's errors, in the same shape the
+    # other failure modes use (item / error / error_type).
+    assert len(result.errors) == 1
+    entry = result.errors[0]
+    assert entry["error_type"] == "RuntimeError"
+    assert "vector store unreachable" in entry["error"]
+    assert entry["item"]["question"] == "What is RAG?"
+
+    # (c) The failure is logged, naming the exception.
+    assert "RuntimeError" in caplog.text
+    assert "vector store unreachable" in caplog.text


### PR DESCRIPTION
## Description

`Pipeline._retrieve` wrapped retrieval in a bare `except Exception` and degraded to the dataset-context fallback with nothing logged, so a completely broken retriever — bad credentials, unreachable vector store, a bug in its own code — produced exactly the same observable result as a retriever that ran fine and found nothing.

The fallback is unchanged. The failure is now logged, naming the exception, so a degraded run can be told apart from a clean one. The `inspect.signature` fallback next to it gets the same treatment.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] CI/CD update

## Related Issues

Closes #256

## How Has This Been Tested?

- [x] Unit tests pass (`uv run pytest tests/unit -v --tb=short` → 1013 passed, 4 skipped; the skips are pre-existing environment skips)
- [x] Whole suite with coverage, matching the CI `Coverage` job (`uv run pytest --cov=openagent_eval --cov-fail-under=75` → 1067 passed, 81.12%)
- [ ] Linter passes (`uv run ruff check .`) — see note below
- [ ] Type checker passes (`uv run mypy openagent_eval/`) — see note below
- [x] Manual testing performed

A regression test drives a retriever whose `retrieve()` raises, through the real pipeline, over a dataset item carrying a `context`. It asserts the fallback still returns that context, that the exception is now visible in the log, **and that `result.errors` stays empty** — that last assertion is deliberate, and the reason is below. Reverting the production change makes it fail; the failure output is the `RuntimeError` no longer appearing.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**On the choice you were asked to make in #256.** The issue offered you two options — a log line only, or a log line plus an entry in the run's `errors` — and said the `errors` entry "would be better still". I built that version first, and it is wrong. Recording a non-fatal degradation in `errors` corrupts the run's arithmetic:

`engine.py:83` computes `successful_evaluations = len(result.results) - len(result.errors)`. The existing defensive boundary in `pipeline.py` gets away with appending to `errors` because it *also* pushes a placeholder result, so the two cancel in that subtraction. A retrieval degradation has no such pairing — the item genuinely succeeds — so each one silently subtracts a success.

Measured on a one-item run where retrieval degraded and the item still evaluated: `successful_evaluations` reported `0` when the true value was `1`, and `failed_evaluations` reported `1` when the true value was `0`. It also flows into `summary["errors"]`, into every renderer's failure section via `reports/base.py`, into the CLI's `Errors: N`, and — the one that decided it — into `cicd/plugin.py`, which flattens `failed_evaluations` into gate metrics. A user gating on `failed_evaluations == 0` would start failing CI on a perfectly healthy run.

So this PR is the log-only version. It trades none of that away and still delivers what #256 asked for: a broken retriever is now distinguishable from an empty one. The test pins `result.errors == []` so that a future change reintroducing the entry is caught rather than quietly mis-counting.

If you do want per-run structured visibility, I think it needs a channel no existing consumer reads as "failed item" — a `warnings` or `degradations` list on `PipelineResult` rather than an entry in `errors`. Happy to send that separately if you'd like it.

**On the two unchecked test boxes.** `ruff check .` exits 1 on pre-existing findings at `main` itself, so I could not honestly tick that. Instead I compared per-file, at `main` and on this branch, for the files this PR touches: `pipeline.py` has the same two pre-existing `TC001` findings on both sides and the new test file is clean, so this diff adds nothing new. I have not reformatted or fixed those pre-existing findings, since that would bury a small behavioural change in unrelated churn. The `mypy` box is unticked for the same reason — it is not clean at `main`, and this diff does not change that.

**Out of scope, noted rather than fixed:** `_generate` has the same bare-`except` shape a few lines below. I left it alone to keep this diff to the issue, but it is the same class if you want it covered.

Generated by Claude Opus 5 (brief, review), Kimi K3 (implementation)
