### PR TITLE
fix(repo): anchor the config.yaml ignore rule to the repository root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,7 +237,7 @@ tiktoken-docs.md
 /data/
 
 # Local config files (contains local settings, use env vars for secrets)
-config.yaml
+/config.yaml
 config.groq.yaml
 config.*.yaml
 


### PR DESCRIPTION
## Description

The root `.gitignore` carried a bare `config.yaml` rule. A gitignore pattern with no slash in it is unanchored and matches at **any** depth, so it also swallowed example configs under `examples/` that are meant to be committed — `git add` exits 0 and stages nothing, with no warning. This anchors the rule to the repository root (`/config.yaml`), which keeps the developer-secret protection exactly where it was intended and stops it reaching nested paths.

`.gitignore` is the only file changed.

**Why anchoring rather than a negation.** #248 offered both `/config.yaml` and a `!examples/**/config.yaml` negation. Anchoring is the narrower and more predictable of the two: it fixes every directory at once rather than carving out one, and it cannot be defeated by a parent-directory exclusion the way a negation can. Happy to switch to the negation form if you would rather keep the rule broad — your call.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] CI/CD update

## Related Issues

Closes #248

## How Has This Been Tested?

Both halves were checked, because the second is what proves the protection was not simply deleted.

Before, on a clean checkout of `main`:

```
$ git check-ignore -v examples/demo/config.yaml
.gitignore:240:config.yaml	examples/demo/config.yaml
$ git check-ignore -v config.yaml
.gitignore:240:config.yaml	config.yaml
```

After:

```
$ git check-ignore -v examples/demo/config.yaml
(exit 1 — no longer ignored)
$ git check-ignore -v config.yaml
.gitignore:240:/config.yaml	config.yaml
```

Full suite, single process, as the Coverage job runs it (`uv run --no-sync pytest --cov=openagent_eval --cov-report=term-missing --cov-fail-under=75`):

```
=========== 1066 passed, 4 skipped, 10 warnings in 153.17s (0:02:33) ===========
Required test coverage of 75% reached. Total coverage: 81.08%
```

Identical to the base, as expected for a `.gitignore`-only change.

- [x] Unit tests pass (`uv run pytest`)
- [ ] Linter passes (`uv run ruff check .`) — not ticked: `ruff check .` exits non-zero on pre-existing findings at `main` itself, so this box cannot be honestly ticked on any PR here. This change touches no Python and adds no findings.
- [ ] Type checker passes (`uv run mypy openagent_eval/`) — not ticked, same reason; also unaffected by a `.gitignore` change.
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — n/a, the existing comment above the rule still describes it correctly
- [ ] I have made corresponding changes to the documentation — n/a, no documented behaviour changes
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective — not ticked: gitignore matching is not reachable from the Python test suite. The `git check-ignore -v` transcripts above are the evidence, in both directions.
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Bug discovered while doing this work, filed separately:**

- #264 [BUG] The remaining unanchored config.*.yaml rule in .gitignore silently excludes example configs

That one is the same defect on `.gitignore:242`, which this PR deliberately leaves alone so it closes #248 exactly as written. Two details worth having from that investigation: `config.*.yaml` on line 242 already subsumes `config.groq.yaml` on line 241 (git reports 242 as the matching rule, so 241 never fires), and line 242 does **not** cover line 240, because the `*` sits between two dots and cannot match an empty middle. Say the word and I will fold the anchoring of line 242 into this PR instead of a second one.

Generated by Claude Opus 5 (brief, review), Kimi K2.7 Code (implementation)
