### PR TITLE
ci: point the type-check step at the real package instead of a nonexistent src/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,11 @@ jobs:
         continue-on-error: true
 
       - name: Run MyPy type checker
-        run: uv run mypy src --ignore-missing-imports || true
+        run: |
+          # A missing target is a config error, not a finding: surface it
+          # instead of letting `|| true` report success.
+          test -d openagent_eval
+          uv run mypy openagent_eval --ignore-missing-imports || true
         continue-on-error: true
 
   # ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

`.github/workflows/ci.yml` pointed the type-check step at `src`, which does not exist — the package is `openagent_eval/` at the repo root. mypy exited 2 with `Cannot read file 'src'`, `|| true` swallowed it, and the step reported success, so the package has never actually been type-checked while appearing to be.

This points the step at the real package and adds a `test -d openagent_eval` guard first, because a path that cannot be read is a configuration error rather than a finding, and should not be able to hide behind `|| true` again.

Your own PR template already names the correct path (`uv run mypy openagent_eval/`), so the workflow was the only place still carrying `src`.

## Type of Change

- [x] CI/CD update

## Related Issues

Closes #250

## How Has This Been Tested?

- [x] Unit tests pass (`uv run pytest`) — untouched by this change
- [x] Linter passes (`uv run ruff check .`) — untouched
- [ ] Type checker passes (`uv run mypy openagent_eval/`) — **no, and that is the point of the issue**

Before, on the old target:

```
mypy: error: Cannot read file 'src': No such file or directory
Found 1 error in 1 file (errors prevented further checking)
```

After, on the real package:

```
Found 121 errors in 46 files (checked 156 source files)
```

YAML re-parsed to confirm the block is still valid.

**I deliberately kept `|| true`.** Turning 121 pre-existing findings into a hard CI failure is your call, not something to smuggle into a path fix — and the neighbouring ruff steps are advisory the same way. The number is here so you can decide when it is worth dropping.

## Follow-ups / Known Limitations

**One honest limit on the guard.** The step also carries `continue-on-error: true`, so a missing target now shows up as a *failed step* rather than a silently green one — but the job itself still passes. That is a real improvement in visibility over `|| true` reporting success, and it is as far as this change goes; making it actually fail the job means dropping `continue-on-error`, which is the same kind of decision as dropping `|| true` and equally yours.

I have not touched any of the 121 findings, and no type annotations were added — that backlog is a separate piece of work.

Generated by Claude Opus 5 (brief, review), Kimi K2.7 Code (implementation)
