### PR TITLE
fix(repo): anchor the remaining config.*.yaml ignore rule to the repository root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,8 +238,7 @@ tiktoken-docs.md
 
 # Local config files (contains local settings, use env vars for secrets)
 /config.yaml
-config.groq.yaml
-config.*.yaml
+/config.*.yaml
 
 # Generated eval report artifacts
 /reports/


### PR DESCRIPTION
## Description

Closes #264. The sibling of #265, which you merged an hour ago.

`#265` anchored `config.yaml` → `/config.yaml`. The wildcard rule one line below it was still unanchored, so it matched example configs anywhere in the tree:

```
.gitignore:242:config.*.yaml	examples/demo/config.groq.yaml
.gitignore:242:config.*.yaml	examples/demo/config.dev.yaml
```

Same fix, same shape: `config.*.yaml` → `/config.*.yaml`. The `config.groq.yaml` line above it is dropped as redundant — `git check-ignore -v` attributes that path to the wildcard on 242, never to 241, since the wildcard is the last matching rule and already covers it.

The section is now just:

```
/config.yaml
/config.*.yaml
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Closes #264

## How Has This Been Tested?

- [x] Unit tests pass — `uv run pytest tests/unit -v --tb=short` → **1015 passed, 4 skipped**

Behavioural proof both directions, since that is the whole point of an ignore-rule fix:

**Before** — example configs wrongly ignored:
```
.gitignore:242:config.*.yaml	examples/demo/config.groq.yaml
.gitignore:242:config.*.yaml	examples/demo/config.dev.yaml
```

**After** — they are visible, and the rule still does its real job at the root:
```
NOT IGNORED: examples/demo/config.groq.yaml
NOT IGNORED: examples/demo/config.dev.yaml
.gitignore:241:/config.*.yaml	config.groq.yaml
.gitignore:241:/config.*.yaml	config.dev.yaml
```

Note `uv sync --all-extras` touched `uv.lock` locally while setting up to run your tests; it is deliberately not staged, so this commit is `.gitignore` and nothing else.

Generated by Claude Opus 5 (brief, review), Kimi K2.7 Code (implementation)
