### PR TITLE
Remove the dead execute_parallel and execute_sequential methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Removed
+
+- **Dead Executor Methods** — remove `Executor.execute_parallel()` and `Executor.execute_sequential()`, which had no production callers (the pipeline uses `Executor.gather()`); their only in-tree references were two dedicated unit tests (#52)
+
 ---
 
 ## [0.4.8] - 2026-07-24

--- a/openagent_eval/core/executor.py
+++ b/openagent_eval/core/executor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Callable, Coroutine
+from typing import Any, Callable
 
 from openagent_eval.exceptions import MetricExecutionError
 
@@ -27,48 +27,6 @@ class Executor:
         self.timeout = timeout
         self._semaphore = asyncio.Semaphore(max_workers)
         self._thread_pool: ThreadPoolExecutor | None = None
-
-    async def execute_parallel(
-        self,
-        tasks: list[Callable[..., Coroutine[Any, Any, Any]]],
-        *args: Any,
-        **kwargs: Any,
-    ) -> list[Any]:
-        """Execute multiple tasks in parallel with concurrency limits.
-
-        Args:
-            tasks: List of async functions to execute.
-            *args: Positional arguments to pass to each task.
-            **kwargs: Keyword arguments to pass to each task.
-
-        Returns:
-            List of results from each task.
-
-        Raises:
-            MetricExecutionError: If a task fails or times out.
-        """
-        async def _run_with_semaphore(
-            task: Callable[..., Coroutine[Any, Any, Any]],
-        ) -> Any:
-            async with self._semaphore:
-                try:
-                    return await asyncio.wait_for(
-                        task(*args, **kwargs),
-                        timeout=self.timeout,
-                    )
-                except asyncio.TimeoutError:
-                    raise MetricExecutionError(
-                        message=f"Task timed out after {self.timeout}s",
-                        details={"timeout": self.timeout},
-                    )
-                except Exception as e:
-                    raise MetricExecutionError(
-                        message=f"Task failed: {e}",
-                        original_error=e,
-                    ) from e
-
-        coroutines = [_run_with_semaphore(task) for task in tasks]
-        return await asyncio.gather(*coroutines)
 
     async def gather(self, coroutines: list[Any]) -> list[Any]:
         """Run coroutines concurrently with the configured concurrency limit.
@@ -103,45 +61,6 @@ class Executor:
             raise eg.exceptions[0] from None
 
         return [t.result() for t in tasks]
-
-    async def execute_sequential(
-        self,
-        tasks: list[Callable[..., Coroutine[Any, Any, Any]]],
-        *args: Any,
-        **kwargs: Any,
-    ) -> list[Any]:
-        """Execute tasks sequentially.
-
-        Args:
-            tasks: List of async functions to execute.
-            *args: Positional arguments to pass to each task.
-            **kwargs: Keyword arguments to pass to each task.
-
-        Returns:
-            List of results from each task.
-
-        Raises:
-            MetricExecutionError: If a task fails.
-        """
-        results: list[Any] = []
-        for task in tasks:
-            try:
-                result = await asyncio.wait_for(
-                    task(*args, **kwargs),
-                    timeout=self.timeout,
-                )
-                results.append(result)
-            except asyncio.TimeoutError:
-                raise MetricExecutionError(
-                    message=f"Task timed out after {self.timeout}s",
-                    details={"timeout": self.timeout},
-                )
-            except Exception as e:
-                raise MetricExecutionError(
-                    message=f"Task failed: {e}",
-                    original_error=e,
-                ) from e
-        return results
 
     async def run_in_thread(
         self,

--- a/tests/unit/test_core/test_engine.py
+++ b/tests/unit/test_core/test_engine.py
@@ -68,28 +68,6 @@ class TestExecutor:
         assert executor.max_workers == 2
         assert executor.timeout == 60.0
 
-    @pytest.mark.asyncio
-    async def test_execute_parallel(self) -> None:
-        """Test parallel execution."""
-        executor = Executor(max_workers=2)
-
-        async def fake_task(x: int) -> int:
-            return x * 2
-
-        results = await executor.execute_parallel([fake_task, fake_task], 5)
-        assert results == [10, 10]
-
-    @pytest.mark.asyncio
-    async def test_execute_sequential(self) -> None:
-        """Test sequential execution."""
-        executor = Executor(max_workers=2)
-
-        async def fake_task(x: int) -> int:
-            return x * 2
-
-        results = await executor.execute_sequential([fake_task, fake_task], 5)
-        assert results == [10, 10]
-
 
 class TestPipeline:
     """Tests for the evaluation pipeline."""


### PR DESCRIPTION
## Summary

Removes `Executor.execute_parallel` and `Executor.execute_sequential`, which nothing in the package calls, along with the two unit tests that were their only callers.

## Related Issues and Pull Requests

Fixes #52

## Changes

- `openagent_eval/core/executor.py` — deletes both methods.
- `tests/unit/test_core/test_engine.py` — deletes `test_execute_parallel` and `test_execute_sequential`.
- `CHANGELOG.md` — entry under `[Unreleased]` → `### Removed`, following #204's shape.

**Chose deletion over the TODO marker your issue also offered.** The precedent is this repo's own: #75 and #77 were both dead-code findings resolved by deletion and merged. There's no TODO-marker precedent to follow, the methods appear in no docs, examples, changelog or release notes, and the package is pre-1.0 with no deprecation convention. Happy to switch to markers if you'd rather keep them as an intended API.

## Testing

One correction to the issue worth stating plainly: **"never called anywhere" isn't quite right — they had two dedicated unit tests.** No production caller exists, which is what makes deletion correct, but `tests/unit/test_core/test_engine.py` called them at four points, so those tests had to go with the methods or the suite would `AttributeError`. That's why the unit count drops by exactly two.

Verified as an enumeration rather than a spot check. Post-change, `grep -rn "execute_parallel\|execute_sequential"` over the whole tree — source, tests, docs, examples, scripts, config — returns exactly one hit: the CHANGELOG entry itself. A `hasattr` check on the class confirms both are gone.

| gate | result |
|---|---|
| `pytest tests/unit` | 1013 passed, 4 skipped (baseline 1015 — the two deleted tests) |
| full suite w/ coverage | 1067 passed, 4 skipped (baseline 1069) |
| coverage | **81.18%**, threshold 75. `executor.py` goes 55 stmts/85% → 33 stmts/**100%** |
| `mkdocs build --strict` | pass |
| `python -m build` + `twine check` | pass |

The soft gates add no new findings — checked at finding level against a base worktree rather than by comparing totals: ruff 224 vs 228 at base, format clean, mypy unchanged, integration 54 passed.

## Footer

Generated by Claude Opus 5 (review), Kimi K3 (brief, implementation, verification)
