### PR TITLE
fix(exceptions): record explicitly-supplied falsy details instead of dropping them

### DIFF
--- a/openagent_eval/exceptions/cli.py
+++ b/openagent_eval/exceptions/cli.py
@@ -28,7 +28,7 @@ class CLIError(OpenAgentEvalError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if command:
+        if command is not None:
             error_details["command"] = command
 
         super().__init__(message=message, details=error_details)

--- a/openagent_eval/exceptions/config.py
+++ b/openagent_eval/exceptions/config.py
@@ -31,9 +31,9 @@ class ConfigurationError(OpenAgentEvalError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if config_path:
+        if config_path is not None:
             error_details["config_path"] = config_path
-        if field:
+        if field is not None:
             error_details["field"] = field
 
         super().__init__(message=message, details=error_details)

--- a/openagent_eval/exceptions/corpus.py
+++ b/openagent_eval/exceptions/corpus.py
@@ -28,7 +28,7 @@ class CorpusError(OpenAgentEvalError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if corpus_path:
+        if corpus_path is not None:
             error_details["corpus_path"] = corpus_path
 
         super().__init__(message=message, details=error_details)
@@ -72,7 +72,7 @@ class CorpusValidationError(CorpusError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if validation_errors:
+        if validation_errors is not None:
             error_details["validation_errors"] = validation_errors
 
         super().__init__(message=message, corpus_path=corpus_path, details=error_details)
@@ -100,9 +100,9 @@ class CorpusAuditError(CorpusError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if analyzer_name:
+        if analyzer_name is not None:
             error_details["analyzer_name"] = analyzer_name
-        if original_error:
+        if original_error is not None:
             error_details["original_error"] = str(original_error)
 
         super().__init__(message=message, corpus_path=corpus_path, details=error_details)

--- a/openagent_eval/exceptions/dataset.py
+++ b/openagent_eval/exceptions/dataset.py
@@ -28,7 +28,7 @@ class DatasetError(OpenAgentEvalError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if dataset_path:
+        if dataset_path is not None:
             error_details["dataset_path"] = dataset_path
 
         super().__init__(message=message, details=error_details)
@@ -79,7 +79,7 @@ class InvalidDatasetError(DatasetError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if data_format:
+        if data_format is not None:
             error_details["format"] = data_format
         if line_number is not None:
             error_details["line_number"] = line_number
@@ -112,7 +112,7 @@ class DatasetValidationError(DatasetError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if validation_errors:
+        if validation_errors is not None:
             error_details["validation_errors"] = validation_errors
 
         super().__init__(message=message, dataset_path=dataset_path, details=error_details)

--- a/openagent_eval/exceptions/metric.py
+++ b/openagent_eval/exceptions/metric.py
@@ -28,7 +28,7 @@ class MetricError(OpenAgentEvalError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if metric_name:
+        if metric_name is not None:
             error_details["metric_name"] = metric_name
 
         super().__init__(message=message, details=error_details)
@@ -52,7 +52,7 @@ class MetricNotFoundError(MetricError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if available_metrics:
+        if available_metrics is not None:
             error_details["available_metrics"] = available_metrics
 
         message = f"Metric not found: {metric_name}"
@@ -86,7 +86,7 @@ class MetricExecutionError(MetricError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if original_error:
+        if original_error is not None:
             error_details["original_error"] = str(original_error)
 
         super().__init__(message=message, metric_name=metric_name, details=error_details)

--- a/openagent_eval/exceptions/plugin.py
+++ b/openagent_eval/exceptions/plugin.py
@@ -28,7 +28,7 @@ class PluginError(OpenAgentEvalError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if plugin_name:
+        if plugin_name is not None:
             error_details["plugin_name"] = plugin_name
 
         super().__init__(message=message, details=error_details)
@@ -52,7 +52,7 @@ class PluginNotFoundError(PluginError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if available_plugins:
+        if available_plugins is not None:
             error_details["available_plugins"] = available_plugins
 
         message = f"Plugin not found: {plugin_name}"
@@ -86,7 +86,7 @@ class PluginLoadError(PluginError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if original_error:
+        if original_error is not None:
             error_details["original_error"] = str(original_error)
 
         super().__init__(message=message, plugin_name=plugin_name, details=error_details)

--- a/openagent_eval/exceptions/provider.py
+++ b/openagent_eval/exceptions/provider.py
@@ -31,7 +31,7 @@ class ProviderError(OpenAgentEvalError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if provider_name:
+        if provider_name is not None:
             error_details["provider_name"] = provider_name
 
         super().__init__(message=message, details=error_details)
@@ -68,7 +68,7 @@ class ProviderNotFoundError(ProviderError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if available_providers:
+        if available_providers is not None:
             error_details["available_providers"] = available_providers
 
         message = f"Provider not found: {provider_name}"
@@ -104,7 +104,7 @@ class ProviderConnectionError(ProviderError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if original_error:
+        if original_error is not None:
             error_details["original_error"] = str(original_error)
 
         super().__init__(message=message, provider_name=provider_name, details=error_details)
@@ -136,7 +136,7 @@ class ProviderExecutionError(ProviderError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if original_error:
+        if original_error is not None:
             error_details["original_error"] = str(original_error)
 
         super().__init__(message=message, provider_name=provider_name, details=error_details)

--- a/openagent_eval/exceptions/synthesis.py
+++ b/openagent_eval/exceptions/synthesis.py
@@ -48,7 +48,7 @@ class SynthesisExecutionError(SynthesisError):
             details: Additional context about the error.
         """
         error_details = details or {}
-        if original_error:
+        if original_error is not None:
             error_details["original_error"] = str(original_error)
 
         super().__init__(message=message, details=error_details)

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -6,6 +6,9 @@ from openagent_eval.exceptions import (
     CLIError,
     CommandError,
     ConfigurationError,
+    CorpusAuditError,
+    CorpusError,
+    CorpusValidationError,
     DatasetError,
     DatasetNotFoundError,
     DatasetValidationError,
@@ -23,6 +26,7 @@ from openagent_eval.exceptions import (
     ProviderError,
     ProviderExecutionError,
     ProviderNotFoundError,
+    SynthesisExecutionError,
     ValidationError,
 )
 
@@ -278,3 +282,191 @@ class TestCLIError:
         assert "value" not in error.details
         assert "field" not in str(error)
         assert "value" not in str(error)
+
+
+class TestFalsyDetailRecording:
+    """Explicitly-supplied falsy values (not None) must be recorded in .details.
+
+    Guards must distinguish "not supplied" (None) from a falsy value such as
+    "", 0, False or []. Only None may be dropped from .details.
+    """
+
+    # --- config.py ---
+
+    def test_configuration_error_preserves_empty_config_path(self) -> None:
+        error = ConfigurationError("Invalid config", config_path="")
+        assert "config_path" in error.details
+
+    def test_configuration_error_preserves_empty_field(self) -> None:
+        error = ConfigurationError("Invalid config", field="")
+        assert "field" in error.details
+
+    def test_configuration_error_omits_none_parameters(self) -> None:
+        error = ConfigurationError("Invalid config")
+        assert "config_path" not in error.details
+        assert "field" not in error.details
+
+    # --- cli.py ---
+
+    def test_cli_error_preserves_empty_command(self) -> None:
+        error = CLIError("Invalid command", command="")
+        assert "command" in error.details
+
+    def test_cli_error_omits_none_command(self) -> None:
+        error = CLIError("Invalid command")
+        assert "command" not in error.details
+
+    # --- corpus.py ---
+
+    def test_corpus_error_preserves_empty_corpus_path(self) -> None:
+        error = CorpusError("Corpus error", corpus_path="")
+        assert "corpus_path" in error.details
+
+    def test_corpus_error_omits_none_corpus_path(self) -> None:
+        error = CorpusError("Corpus error")
+        assert "corpus_path" not in error.details
+
+    def test_corpus_validation_error_preserves_empty_validation_errors(self) -> None:
+        error = CorpusValidationError("Validation failed", validation_errors=[])
+        assert "validation_errors" in error.details
+
+    def test_corpus_validation_error_omits_none_validation_errors(self) -> None:
+        error = CorpusValidationError("Validation failed")
+        assert "validation_errors" not in error.details
+
+    def test_corpus_audit_error_preserves_empty_analyzer_name(self) -> None:
+        error = CorpusAuditError("Audit failed", analyzer_name="")
+        assert "analyzer_name" in error.details
+
+    def test_corpus_audit_error_records_original_error(self) -> None:
+        error = CorpusAuditError("Audit failed", original_error=ValueError("boom"))
+        assert "original_error" in error.details
+
+    def test_corpus_audit_error_omits_none_parameters(self) -> None:
+        error = CorpusAuditError("Audit failed")
+        assert "analyzer_name" not in error.details
+        assert "original_error" not in error.details
+
+    # --- dataset.py ---
+
+    def test_dataset_error_preserves_empty_dataset_path(self) -> None:
+        error = DatasetError("Dataset error", dataset_path="")
+        assert "dataset_path" in error.details
+
+    def test_dataset_error_omits_none_dataset_path(self) -> None:
+        error = DatasetError("Dataset error")
+        assert "dataset_path" not in error.details
+
+    def test_invalid_dataset_error_preserves_empty_data_format(self) -> None:
+        error = InvalidDatasetError("Invalid format", data_format="")
+        assert "format" in error.details
+
+    def test_invalid_dataset_error_omits_none_data_format(self) -> None:
+        error = InvalidDatasetError("Invalid format")
+        assert "format" not in error.details
+
+    def test_dataset_validation_error_preserves_empty_validation_errors(self) -> None:
+        error = DatasetValidationError("Validation failed", validation_errors=[])
+        assert "validation_errors" in error.details
+
+    def test_dataset_validation_error_omits_none_validation_errors(self) -> None:
+        error = DatasetValidationError("Validation failed")
+        assert "validation_errors" not in error.details
+
+    # --- metric.py ---
+
+    def test_metric_error_preserves_empty_metric_name(self) -> None:
+        error = MetricError("Metric error", metric_name="")
+        assert "metric_name" in error.details
+
+    def test_metric_error_omits_none_metric_name(self) -> None:
+        error = MetricError("Metric error")
+        assert "metric_name" not in error.details
+
+    def test_metric_not_found_error_preserves_empty_available_metrics(self) -> None:
+        error = MetricNotFoundError("my_metric", available_metrics=[])
+        assert "available_metrics" in error.details
+
+    def test_metric_not_found_error_omits_none_available_metrics(self) -> None:
+        error = MetricNotFoundError("my_metric")
+        assert "available_metrics" not in error.details
+
+    def test_metric_execution_error_records_original_error(self) -> None:
+        error = MetricExecutionError("Failed", original_error=ValueError("boom"))
+        assert "original_error" in error.details
+
+    def test_metric_execution_error_omits_none_original_error(self) -> None:
+        error = MetricExecutionError("Failed")
+        assert "original_error" not in error.details
+
+    # --- plugin.py ---
+
+    def test_plugin_error_preserves_empty_plugin_name(self) -> None:
+        error = PluginError("Plugin error", plugin_name="")
+        assert "plugin_name" in error.details
+
+    def test_plugin_error_omits_none_plugin_name(self) -> None:
+        error = PluginError("Plugin error")
+        assert "plugin_name" not in error.details
+
+    def test_plugin_not_found_error_preserves_empty_available_plugins(self) -> None:
+        error = PluginNotFoundError("my_plugin", available_plugins=[])
+        assert "available_plugins" in error.details
+
+    def test_plugin_not_found_error_omits_none_available_plugins(self) -> None:
+        error = PluginNotFoundError("my_plugin")
+        assert "available_plugins" not in error.details
+
+    def test_plugin_load_error_records_original_error(self) -> None:
+        error = PluginLoadError("Failed to load", original_error=ImportError("boom"))
+        assert "original_error" in error.details
+
+    def test_plugin_load_error_omits_none_original_error(self) -> None:
+        error = PluginLoadError("Failed to load")
+        assert "original_error" not in error.details
+
+    # --- provider.py ---
+
+    def test_provider_error_preserves_empty_provider_name(self) -> None:
+        error = ProviderError("Provider error", provider_name="")
+        assert "provider_name" in error.details
+
+    def test_provider_error_omits_none_provider_name(self) -> None:
+        error = ProviderError("Provider error")
+        assert "provider_name" not in error.details
+
+    def test_provider_not_found_error_preserves_empty_available_providers(self) -> None:
+        error = ProviderNotFoundError("my_provider", available_providers=[])
+        assert "available_providers" in error.details
+
+    def test_provider_not_found_error_omits_none_available_providers(self) -> None:
+        error = ProviderNotFoundError("my_provider")
+        assert "available_providers" not in error.details
+
+    def test_provider_connection_error_records_original_error(self) -> None:
+        error = ProviderConnectionError(
+            "Failed to connect", original_error=ConnectionError("boom")
+        )
+        assert "original_error" in error.details
+
+    def test_provider_connection_error_omits_none_original_error(self) -> None:
+        error = ProviderConnectionError("Failed to connect")
+        assert "original_error" not in error.details
+
+    def test_provider_execution_error_records_original_error(self) -> None:
+        error = ProviderExecutionError("API call failed", original_error=RuntimeError("boom"))
+        assert "original_error" in error.details
+
+    def test_provider_execution_error_omits_none_original_error(self) -> None:
+        error = ProviderExecutionError("API call failed")
+        assert "original_error" not in error.details
+
+    # --- synthesis.py ---
+
+    def test_synthesis_execution_error_records_original_error(self) -> None:
+        error = SynthesisExecutionError("Synthesis failed", original_error=RuntimeError("boom"))
+        assert "original_error" in error.details
+
+    def test_synthesis_execution_error_omits_none_original_error(self) -> None:
+        error = SynthesisExecutionError("Synthesis failed")
+        assert "original_error" not in error.details

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -31,6 +31,13 @@ from openagent_eval.exceptions import (
 )
 
 
+class FalsyException(Exception):
+    """Exception whose truthiness is false despite being an exception."""
+
+    def __bool__(self) -> bool:
+        return False
+
+
 class TestOpenAgentEvalError:
     """Tests for the base exception class."""
 
@@ -342,6 +349,12 @@ class TestFalsyDetailRecording:
         error = CorpusAuditError("Audit failed", original_error=ValueError("boom"))
         assert "original_error" in error.details
 
+    def test_corpus_audit_error_preserves_falsy_original_error(self) -> None:
+        original_error = FalsyException("boom")
+        error = CorpusAuditError("Audit failed", original_error=original_error)
+        assert "original_error" in error.details
+        assert error.original_error is original_error
+
     def test_corpus_audit_error_omits_none_parameters(self) -> None:
         error = CorpusAuditError("Audit failed")
         assert "analyzer_name" not in error.details
@@ -395,6 +408,12 @@ class TestFalsyDetailRecording:
         error = MetricExecutionError("Failed", original_error=ValueError("boom"))
         assert "original_error" in error.details
 
+    def test_metric_execution_error_preserves_falsy_original_error(self) -> None:
+        original_error = FalsyException("boom")
+        error = MetricExecutionError("Failed", original_error=original_error)
+        assert "original_error" in error.details
+        assert error.original_error is original_error
+
     def test_metric_execution_error_omits_none_original_error(self) -> None:
         error = MetricExecutionError("Failed")
         assert "original_error" not in error.details
@@ -420,6 +439,12 @@ class TestFalsyDetailRecording:
     def test_plugin_load_error_records_original_error(self) -> None:
         error = PluginLoadError("Failed to load", original_error=ImportError("boom"))
         assert "original_error" in error.details
+
+    def test_plugin_load_error_preserves_falsy_original_error(self) -> None:
+        original_error = FalsyException("boom")
+        error = PluginLoadError("Failed to load", original_error=original_error)
+        assert "original_error" in error.details
+        assert error.original_error is original_error
 
     def test_plugin_load_error_omits_none_original_error(self) -> None:
         error = PluginLoadError("Failed to load")
@@ -449,6 +474,12 @@ class TestFalsyDetailRecording:
         )
         assert "original_error" in error.details
 
+    def test_provider_connection_error_preserves_falsy_original_error(self) -> None:
+        original_error = FalsyException("boom")
+        error = ProviderConnectionError("Failed to connect", original_error=original_error)
+        assert "original_error" in error.details
+        assert error.original_error is original_error
+
     def test_provider_connection_error_omits_none_original_error(self) -> None:
         error = ProviderConnectionError("Failed to connect")
         assert "original_error" not in error.details
@@ -456,6 +487,12 @@ class TestFalsyDetailRecording:
     def test_provider_execution_error_records_original_error(self) -> None:
         error = ProviderExecutionError("API call failed", original_error=RuntimeError("boom"))
         assert "original_error" in error.details
+
+    def test_provider_execution_error_preserves_falsy_original_error(self) -> None:
+        original_error = FalsyException("boom")
+        error = ProviderExecutionError("API call failed", original_error=original_error)
+        assert "original_error" in error.details
+        assert error.original_error is original_error
 
     def test_provider_execution_error_omits_none_original_error(self) -> None:
         error = ProviderExecutionError("API call failed")
@@ -466,6 +503,12 @@ class TestFalsyDetailRecording:
     def test_synthesis_execution_error_records_original_error(self) -> None:
         error = SynthesisExecutionError("Synthesis failed", original_error=RuntimeError("boom"))
         assert "original_error" in error.details
+
+    def test_synthesis_execution_error_preserves_falsy_original_error(self) -> None:
+        original_error = FalsyException("boom")
+        error = SynthesisExecutionError("Synthesis failed", original_error=original_error)
+        assert "original_error" in error.details
+        assert error.original_error is original_error
 
     def test_synthesis_execution_error_omits_none_original_error(self) -> None:
         error = SynthesisExecutionError("Synthesis failed")


### PR DESCRIPTION
## Description

Exception constructors guarded their detail recording with a truthiness test, so an explicitly-supplied empty string, `0`, `False`, or `[]` was silently dropped from `.details` while only `None` should have meant "not supplied". This changes 21 such guards across the eight exception modules to test `is not None`.

The same defect was fixed for `ValidationError` in #279 (issue #68). Issue #280 asked whether `ConfigurationError.field` had it too — it does, and so do nineteen further guards in the same package, so this fixes the family rather than the one reported line.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] CI/CD update

## Related Issues

Closes #280

## How Has This Been Tested?

- [x] Unit tests pass (`uv run pytest`)
- [ ] Linter passes (`uv run ruff check .`)
- [ ] Type checker passes (`uv run mypy openagent_eval/`)
- [ ] Manual testing performed

`tests/unit/test_exceptions.py` grew from 29 to 78 cases: one preservation case per touched module, non-string falsy values where the parameter type allows, and a negative case per module asserting that an unsupplied (`None`) parameter is still absent from `.details` — without that, "fix" could quietly degrade into "record everything".

The tests were confirmed to actually fail against unfixed sources: with the new tests in place and `openagent_eval/exceptions/` restored to `main`, they fail; with the fix, 78 pass. They assert membership (`assert "field" in exc.details`) rather than indexing, so a missing key fails as an assertion rather than a `KeyError`.

Six of the guards take an `original_error`. Ordinary exception instances are truthy, so a test passing a plain `ValueError` would have passed against the old code too and proved nothing — those six are covered with an exception subclass whose `__bool__` returns `False`, which is a real shape (an exception wrapping an empty collection inherits its `__len__`).

Full `pytest tests/unit` and the coverage gate ran green on a runner for this branch on Python 3.11 and 3.12.

The two unticked boxes are unticked deliberately rather than overlooked. `ruff check .` fails at `main` on pre-existing findings unrelated to this change, so it cannot pass here; `ruff check` limited to the changed files is clean. `mypy openagent_eval/` is likewise not clean at `main`. Neither is a blocking gate in CI, and reporting an unrun or failing gate as passing seemed worse than saying so.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — no documented behaviour changes
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Guards deliberately left alone, in case it looks like an omission: `base.py:26` and `provider.py:42,44,46` format details that are already recorded rather than deciding what to record; `provider.py:75`, `metric.py:59` and `plugin.py:59` build message text, so changing them would alter user-visible wording; `diagnosis.py:41`, `dataset.py:84`, `cli.py:90`, `cli.py:92` and `metric.py:119` already test `is not None`.

Generated by Claude Opus 5 (brief, review), Kimi K3 (implementation), GPT-5.6-Luna (implementation), GPT-5.6-Sol (verification)
