### PR TITLE
Handle None latency gracefully in PerformanceCostMetric

### DIFF
--- a/openagent_eval/metrics/performance/latency.py
+++ b/openagent_eval/metrics/performance/latency.py
@@ -40,8 +40,15 @@ class LatencyMetric(BaseMetric):
         Returns:
             MetricResult with latency score.
         """
-        latency_ms = kwargs.get("latency_ms", 0.0)
+        latency_ms = kwargs.get("latency_ms")
         stage = kwargs.get("stage", "unknown")
+
+        if latency_ms is None:
+            return MetricResult(
+                score=0.0,
+                reason="No latency measurement available",
+                metadata={"stage": stage, "latency_ms": None},
+            )
 
         if latency_ms < 0:
             return MetricResult(

--- a/tests/unit/test_metrics/test_performance_cost.py
+++ b/tests/unit/test_metrics/test_performance_cost.py
@@ -56,6 +56,17 @@ class TestLatencyMetric:
         assert result.metadata["stage"] == "embedding"
         assert result.metadata["latency_ms"] == 100.0
 
+    def test_none_latency_does_not_raise(self):
+        """None latency (e.g. no LLM configured, or generation failure) is handled gracefully."""
+        result = self.metric.evaluate(latency_ms=None, stage="llm")
+        assert result.score == 0.0
+        assert result.metadata["latency_ms"] is None
+
+    def test_missing_latency_kwarg_does_not_raise(self):
+        """Omitting latency_ms entirely behaves the same as passing None."""
+        result = self.metric.evaluate(stage="llm")
+        assert result.score == 0.0
+
 
 class TestTokenCountMetric:
     """Tests for TokenCountMetric."""


### PR DESCRIPTION
## Description

This PR improves the robustness of the `PerformanceCostMetric.evaluate()` method to gracefully handle cases where latency measurement is unavailable (e.g., when no LLM is configured or generation fails).

Previously, the method defaulted missing `latency_ms` to `0.0`, which could mask scenarios where latency data was genuinely unavailable. Now it explicitly checks for `None` values and returns a score of `0.0` with appropriate metadata indicating that no measurement was available.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

## How Has This Been Tested?

Added two new unit tests:
- `test_none_latency_does_not_raise`: Verifies that explicitly passing `latency_ms=None` is handled gracefully
- `test_missing_latency_kwarg_does_not_raise`: Verifies that omitting `latency_ms` entirely behaves the same as passing `None`

Both tests confirm that the metric returns a score of `0.0` and includes appropriate metadata.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

This change improves observability by distinguishing between "no latency measurement available" (returns `0.0` with `latency_ms: None` in metadata) and actual latency values, making it easier to debug scenarios where latency data is missing.

https://claude.ai/code/session_01WBiH9ViQkKjAr6knTz4AWA