### PR TITLE
fix(metrics): compute occurrence-based ROUGE recall fallback

### DIFF
--- a/openagent_eval/metrics/generation/rouge.py
+++ b/openagent_eval/metrics/generation/rouge.py
@@ -5,6 +5,7 @@ Measures overlap between answer and ground truth using ROUGE scores.
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any
 
 from openagent_eval.metrics.base import BaseMetric, MetricResult
@@ -65,9 +66,14 @@ class ROUGE(BaseMetric):
         )
 
     def _evaluate_simple(self, answer: str, ground_truth: str) -> MetricResult:
-        """Simple unigram recall fallback."""
-        answer_words = set(answer.lower().split())
-        truth_words = set(ground_truth.lower().split())
+        """Simple unigram recall fallback over word occurrences.
+
+        Overlap is counted per occurrence (not per word type), so a term
+        repeated in the reference contributes to the recall denominator
+        each time it appears.
+        """
+        answer_words = answer.lower().split()
+        truth_words = ground_truth.lower().split()
 
         if not truth_words:
             return MetricResult(
@@ -76,11 +82,13 @@ class ROUGE(BaseMetric):
                 metadata={"method": "simple_recall"},
             )
 
-        overlap = answer_words & truth_words
-        recall = len(overlap) / len(truth_words)
+        answer_counts = Counter(answer_words)
+        truth_counts = Counter(truth_words)
+        overlap = sum((answer_counts & truth_counts).values())
+        recall = overlap / sum(truth_counts.values())
 
         return MetricResult(
             score=recall,
             reason=f"Simple ROUGE recall: {recall:.4f}",
-            metadata={"method": "simple_recall", "overlap": len(overlap)},
+            metadata={"method": "simple_recall", "overlap": overlap},
         )

--- a/tests/unit/test_metrics/test_generation.py
+++ b/tests/unit/test_metrics/test_generation.py
@@ -172,6 +172,26 @@ class TestROUGE:
         )
         assert result.score < 0.5
 
+    def test_fallback_sensitive_to_repetition(self, monkeypatch):
+        """Fallback recall counts occurrences, not unique word types."""
+        def _force_fallback(*args, **kwargs):
+            raise ImportError("force fallback path")
+
+        monkeypatch.setattr(self.metric, "_evaluate_with_hf", _force_fallback)
+
+        partial = self.metric.evaluate(
+            answer="cat",
+            ground_truth="cat cat cat",
+        )
+        full = self.metric.evaluate(
+            answer="cat cat cat",
+            ground_truth="cat cat cat",
+        )
+
+        assert partial.score == pytest.approx(1 / 3)
+        assert full.score == 1.0
+        assert partial.metadata["method"] == "simple_recall"
+
 
 class TestSemanticSimilarity:
     """Tests for SemanticSimilarity metric."""


### PR DESCRIPTION
The ROUGE fallback documented itself as unigram recall but deduplicated both sides into sets, so repetition in the reference was ignored and a term repeated many times counted once. Use a Counter intersection over the reference's total token count so recall is sensitive to how many occurrences are recovered.

Fixes #282

## Description

A clear and concise description of what this PR does.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] CI/CD update

## Related Issues

Closes #(issue_number)

## How Has This Been Tested?

Describe the tests that you ran to verify your changes.

- [ ] Unit tests pass (`uv run pytest`)
- [ ] Linter passes (`uv run ruff check .`)
- [ ] Type checker passes (`uv run mypy openagent_eval/`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate visual changes.

## Additional Notes

Add any other notes about the PR here.
