### PR TITLE
fix(engine): use package version in report metadata

### DIFF
--- a/openagent_eval/core/engine.py
+++ b/openagent_eval/core/engine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from openagent_eval import __version__
 from openagent_eval.core.executor import Executor
 from openagent_eval.core.pipeline import Pipeline, PipelineResult
 from openagent_eval.core.registry import Registry
@@ -96,7 +97,7 @@ class Engine:
             result=result,
             summary=summary,
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "engine": "openagent-eval",
                 "llm_provider": getattr(self._llm, "name", None),
                 "retriever_provider": getattr(self._retriever, "name", None),

--- a/tests/unit/test_core/test_engine.py
+++ b/tests/unit/test_core/test_engine.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from openagent_eval import __version__
 from openagent_eval.core.engine import Engine
 from openagent_eval.core.executor import Executor
 from openagent_eval.core.pipeline import EvaluationResult, Pipeline, PipelineResult
@@ -141,6 +142,7 @@ class TestEngine:
         report = await engine.run(sample_dataset)
         assert report.config is sample_config
         assert report.summary["total_items"] == len(sample_dataset)
+        assert report.metadata["version"] == __version__
         engine.shutdown()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #291.

Generated reports were hard-coding version `0.1.0` even though the installed OpenAgent Eval package was `0.4.9`.

This change uses the existing `openagent_eval.__version__` as the single source of truth for report metadata.

## Changes

- Replace the hard-coded report version with `__version__`
- Add a regression test verifying report metadata uses the package version

## Testing

- `uv run pytest tests/unit/test_core/test_engine.py -q` — 13 passed
- `uv run pytest tests/unit/test_reports/test_json_report.py -q` — 18 passed
- `uv run pytest tests/integration/test_pipeline/test_mock_e2e.py -o "addopts=" -q` — 3 passed
- `uv run ruff check openagent_eval/core/engine.py tests/unit/test_core/test_engine.py` — passed
- `uv run ruff format --check openagent_eval/core/engine.py tests/unit/test_core/test_engine.py` — passed
- `git diff --check` — passed

Note: repository-wide Ruff and mypy checks report pre-existing issues outside the files changed in this PR.