### PR TITLE
fix: correct MiMo model ID format in opencode workflow

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -30,4 +30,4 @@ jobs:
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
-          model: opencode/MiMo V2.5 Free
+          model: opencode/mimo-v2.5-free


### PR DESCRIPTION
## Summary

- Changed `opencode/MiMo V2.5 Free` → `opencode/mimo-v2.5-free` in `.github/workflows/opencode.yml`
- The spaces and mixed case in the old value caused the opencode agent to fail with a model-not-found error
- New value follows the same lowercase hyphenated slug convention as previous working models (`opencode/minimax-m2.5-free`, `opencode/deepseek-v4-flash-free`)

## Test plan

- [ ] Comment `/oc` or `/opencode` on an open PR or issue to trigger the workflow
- [ ] Verify the "Run opencode" step completes without a model-not-found error in the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)