### PR TITLE
Add Docker CI workflow and Dockerfile for GHCR auto-publish

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,12 +27,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Lowercase repository owner
+        id: repo
+        run: echo "name=${GITHUB_REPOSITORY_OWNER@L}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/openagent-eval:latest
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/openagent-eval:cache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/openagent-eval:cache,mode=max
+            ghcr.io/${{ steps.repo.outputs.name }}/openagent-eval:latest
+          cache-from: type=registry,ref=ghcr.io/${{ steps.repo.outputs.name }}/openagent-eval:cache
+          cache-to: type=registry,ref=ghcr.io/${{ steps.repo.outputs.name }}/openagent-eval:cache,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,38 @@
+name: Docker CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/openagent-eval:latest
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/openagent-eval:cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/openagent-eval:cache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,24 @@ WORKDIR /app
 # Copy project manifest files
 COPY pyproject.toml uv.lock* ./
 
-# Install only core dependencies for minimal image size
-# --extra-group core matches the "core" extra in pyproject.toml:
-#   typer, rich, pydantic, pyyaml, loguru, jinja2, httpx
-# To include all extras, replace with: --all-extras
-RUN uv pip install --system \
-    --extra-group core \
-    -r pyproject.toml
+# Install core dependencies first (cached layer — only re-runs when this
+# line changes). These mirror the base `dependencies` in pyproject.toml.
+# To include all extras instead, use: uv pip install --system --all-extras .
+RUN uv pip install --system --no-cache \
+    "typer>=0.12.0" \
+    "rich>=13.0.0" \
+    "pydantic>=2.0.0" \
+    "pyyaml>=6.0" \
+    "loguru>=0.7.0" \
+    "jinja2>=3.1.0" \
+    "httpx>=0.27.0"
 
 # Copy source code into the image
 COPY openagent_eval/ /app/openagent_eval/
+
+# Install the package itself (creates the `oaeval` console script).
+# --no-deps skips re-resolving the deps installed above, keeping this fast.
+RUN uv pip install --system --no-cache --no-deps .
 
 # -------------------------------------------------------
 # Stage 2: Runtime — Minimal production image
@@ -48,9 +56,8 @@ COPY --from=builder /app/openagent_eval/ /app/openagent_eval/
 # -------------------------------------------------------
 # Entry point
 # -------------------------------------------------------
-# Use `uv run oaeval` to invoke the CLI entry point
-# This ensures the correct environment (with all installed deps) is used
-ENTRYPOINT ["uv", "run", "oaeval"]
+# `oaeval` console script is installed system-wide in site-packages
+ENTRYPOINT ["oaeval"]
 
 # -------------------------------------------------------
 # Optional: Health check

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 
-# Copy project manifest files
-COPY pyproject.toml uv.lock* ./
+# Copy project manifest files (README.md is required by hatchling metadata)
+COPY pyproject.toml uv.lock* README.md ./
 
 # Install core dependencies first (cached layer — only re-runs when this
 # line changes). These mirror the base `dependencies` in pyproject.toml.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,10 @@
 # -------------------------------------------------------
 FROM python:3.11-slim AS builder
 
-# Install uv (fast Python package resolver and installer)
-# https://github.com/astral/uv
-COPY --from=ghcr.io/astral/uv:0.4.26 /usr/local/bin/uv /usr/local/bin/uv
+# Install uv from the official astral-sh image
+# https://github.com/astral-sh/uv
+# Binary paths are /uv and /uvx in the distroless image
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 
@@ -35,7 +36,8 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Copy uv binary from builder for running the app
-COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=builder /bin/uv /bin/uv
+COPY --from=builder /bin/uvx /bin/uvx
 
 # Copy installed Python packages from builder
 COPY --from=builder /usr/local/lib/python3.11/site-packages/ /usr/local/lib/python3.11/site-packages/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+# Dockerfile for openagent_eval
+# Multi-stage build with uv for fast dependency resolution
+# Base image: python:3.11-slim (matches project's >=3.11 requirement)
+
+# -------------------------------------------------------
+# Stage 1: Build — Install dependencies with uv
+# -------------------------------------------------------
+FROM python:3.11-slim AS builder
+
+# Install uv (fast Python package resolver and installer)
+# https://github.com/astral/uv
+COPY --from=ghcr.io/astral/uv:0.4.26 /usr/local/bin/uv /usr/local/bin/uv
+
+WORKDIR /app
+
+# Copy project manifest files
+COPY pyproject.toml uv.lock* ./
+
+# Install only core dependencies for minimal image size
+# --extra-group core matches the "core" extra in pyproject.toml:
+#   typer, rich, pydantic, pyyaml, loguru, jinja2, httpx
+# To include all extras, replace with: --all-extras
+RUN uv pip install --system \
+    --extra-group core \
+    -r pyproject.toml
+
+# Copy source code into the image
+COPY openagent_eval/ /app/openagent_eval/
+
+# -------------------------------------------------------
+# Stage 2: Runtime — Minimal production image
+# -------------------------------------------------------
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Copy uv binary from builder for running the app
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+
+# Copy installed Python packages from builder
+COPY --from=builder /usr/local/lib/python3.11/site-packages/ /usr/local/lib/python3.11/site-packages/
+
+# Copy application source code
+COPY --from=builder /app/openagent_eval/ /app/openagent_eval/
+
+# -------------------------------------------------------
+# Entry point
+# -------------------------------------------------------
+# Use `uv run oaeval` to invoke the CLI entry point
+# This ensures the correct environment (with all installed deps) is used
+ENTRYPOINT ["uv", "run", "oaeval"]
+
+# -------------------------------------------------------
+# Optional: Health check
+# -------------------------------------------------------
+# Uncomment the following line if you want Docker to monitor container health
+# HEALTHCHECK --interval=30s --timeout=5s CMD oaeval doctor
+
+# -------------------------------------------------------
+# Useful labels (optional but recommended)
+# -------------------------------------------------------
+LABEL \
+    org.opencontainers.image.title="openagent-eval" \
+    org.opencontainers.image.description="CLI framework for evaluating RAG systems and AI Agents" \
+    org.opencontainers.image.version="0.4.10" \
+    org.opencontainers.image.source="https://github.com/vellore-ws/openagent-eval"


### PR DESCRIPTION
## Summary
Add Docker CI workflow and Dockerfile for GitHub Container Registry (GHCR) auto-publish.

## Changes
- \.github/workflows/docker.yml\ — GitHub Actions workflow that automatically builds and pushes Docker image to GHCR on every \main\ push and PR
- \Dockerfile\ — Multi-stage build using \uv\ for fast dependency resolution, \python:3.11-slim\ base image

## How It Works
- On push to \main\ or PR: workflow triggers → builds Docker image → pushes to \ghcr.io/OpenAgentHQ/openagent-eval:latest\
- Users can run: \docker run ghcr.io/OpenAgentHQ/openagent-eval:latest run /app/config.yaml\
- No manual Docker commands needed after setup

## Workflow Triggers
- \push\ to \main\ branch
- \pull request\ against \main\

## Testing
- Workflow runs automatically on PR creation
- Verify in **Actions** tab
- Merge to \main\ to publish the image