### PR TITLE
fix: B015 pointless comparison in test_chroma.py

### DIFF
--- a/tests/unit/test_providers/test_chroma.py
+++ b/tests/unit/test_providers/test_chroma.py
@@ -72,13 +72,15 @@ class TestChromaRetrieverInit:
 
     def test_init_custom_distance_fn(self, mock_chromadb):
         """Retriever uses custom distance function."""
-        _, _, mock_collection = mock_chromadb
+        mock_chroma, mock_client, mock_collection = mock_chromadb
         retriever = ChromaRetriever(
             collection_name="test",
             distance_fn="l2",
         )
         assert retriever.distance_fn == "l2"
-        mock_collection.metadata == {"hnsw:space": "l2"}
+        mock_client.get_or_create_collection.assert_called_once_with(
+            name="test", metadata={"hnsw:space": "l2"}
+        )
 
     def test_init_connection_error(self):
         """Retriever raises ProviderConnectionError on init failure."""


### PR DESCRIPTION
## Description

Fixes B015 lint violation in tests/unit/test_providers/test_chroma.py and corrects the underlying test logic bug.

**Changes:**
1. Line 81: Changed pointless comparison to proper assertion
2. Fixed test logic to verify get_or_create_collection() is called with correct metadata argument instead of checking a mock attribute that doesn't exist

**Root Cause:** In openagent_eval/providers/retrievers/chroma.py:112-115, metadata is passed as an argument to get_or_create_collection(), not set on the returned collection object. The original test checked mock_collection.metadata (a MagicMock) which would always fail.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

## Related Issues

Closes #311

## How Has This Been Tested?

- [x] Unit tests pass (uv run pytest tests/unit/test_providers/test_chroma.py - all 15 tests pass)
- [x] Linter passes (uv run ruff check tests/unit/test_providers/test_chroma.py - B015 resolved)
- [ ] Type checker passes (uv run mypy openagent_eval/) - not run (pre-existing mypy issues)
- [x] Manual testing performed (installed chromadb locally to verify tests run)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (test is self-explanatory)
- [ ] I have made corresponding changes to the documentation (no doc changes needed)
- [x] My changes generate no new warnings (B015 fixed, only pre-existing E402 remain)
- [x] I have added tests that prove my fix is effective or that my feature works (existing test now validates correct behavior)
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Pre-existing issues not addressed in this PR:**
- 3 E402 import ordering violations in test_chroma.py (imports after pytest.importorskip)
- These could be fixed in a follow-up PR if desired

**Questions for reviewers:**
1. Should we also fix the 3 E402 import ordering violations in this file?
2. The test now uses explicit fixture unpacking instead of underscores - is this preferred?
3. Any other chroma-related tests with similar mock verification issues?