### PR TITLE
test: add coverage for default cosine distance metadata in ChromaRetriever init (#315)

### DIFF
--- a/tests/unit/test_providers/test_chroma.py
+++ b/tests/unit/test_providers/test_chroma.py
@@ -82,6 +82,14 @@ class TestChromaRetrieverInit:
             name="test", metadata={"hnsw:space": "l2"}
         )
 
+    def test_init_default_cosine_metadata(self, mock_chromadb):
+        """Default distance_fn passes hnsw:space='cosine' metadata to collection."""
+        _, mock_client, _ = mock_chromadb
+        ChromaRetriever(collection_name="test")
+        mock_client.get_or_create_collection.assert_called_once_with(
+            name="test", metadata={"hnsw:space": "cosine"}
+        )
+
     def test_init_connection_error(self):
         """Retriever raises ProviderConnectionError on init failure."""
         with patch(


### PR DESCRIPTION
## Summary

- Adds 	est_init_default_cosine_metadata to TestChromaRetrieverInit in 	ests/unit/test_providers/test_chroma.py.
- Verifies that when distance_fn is not specified, ChromaRetriever.__init__ creates the collection with metadata={'hnsw:space': 'cosine'} (the default), closing the gap where only the custom l2 case was asserted.

## Changes

- 	ests/unit/test_providers/test_chroma.py: new test mirroring 	est_init_custom_distance_fn.

## Testing

- pytest tests/unit/test_providers/test_chroma.py -> 16 passed
- uff check -> no new issues (pre-existing E402 on importorskip pattern untouched)

## Checklist

- [x] Tests added
- [x] Tests pass
- [x] Lint clean (no new errors)