### PR TITLE
fix: resolve E402 by hoisting imports to top of tutorial notebook cells

### DIFF
--- a/examples/openagent_eval_colab_tutorial.ipynb
+++ b/examples/openagent_eval_colab_tutorial.ipynb
@@ -1744,6 +1744,8 @@
     }
    ],
    "source": [
+    "import operator as _op\n",
+    "\n",
     "scores = report.summary[\"metrics_summary\"]\n",
     "\n",
     "# Define the gates you'd enforce in CI: (metric, operator, threshold).\n",
@@ -1753,7 +1755,6 @@
     "    (\"faithfulness\", \">=\", 0.9),  # deliberately strict to show a failure\n",
     "]\n",
     "\n",
-    "import operator as _op\n",
     "\n",
     "OPS = {\">=\": _op.ge, \">\": _op.gt, \"<=\": _op.le, \"<\": _op.lt, \"==\": _op.eq}\n",
     "\n",

--- a/examples/rag_evaluation_tutorial.ipynb
+++ b/examples/rag_evaluation_tutorial.ipynb
@@ -3421,6 +3421,7 @@
    "source": [
     "# Compare two experiments using ComparisonReport\n",
     "from openagent_eval.reports import ComparisonReport\n",
+    "from openagent_eval.reports.base import ExperimentComparison\n",
     "\n",
     "\n",
     "async def run_experiment_2():\n",
@@ -3446,7 +3447,6 @@
     "report2 = await run_experiment_2()\n",
     "\n",
     "# Build an ExperimentComparison and generate the comparison report\n",
-    "from openagent_eval.reports.base import ExperimentComparison\n",
     "\n",
     "comparison_data = ExperimentComparison(\n",
     "    baseline_name=\"Experiment 1 (k=3)\",\n",


### PR DESCRIPTION
## Description

This PR resolves ruff **E402** (`Module level import not at top of cell`) in the tutorial notebooks by moving module-level imports to the top of their cells, matching the project's lint standards.

- `examples/openagent_eval_colab_tutorial.ipynb` (cell 55): moved `import operator as _op` above the first statement.
- `examples/rag_evaluation_tutorial.ipynb` (cell 45): moved `from openagent_eval.reports.base import ExperimentComparison` to the top of the cell, grouped with the existing `ComparisonReport` import.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] CI/CD update

## Related Issues

Closes #313

## How Has This Been Tested?

- [ ] Unit tests pass (`uv run pytest`)
- [x] Linter passes (`uv run ruff check .`) — E402 resolved; one unrelated SIM115 remains intentionally out of scope (see notes)
- [ ] Type checker passes (`uv run mypy openagent_eval/`)
- [x] Manual testing performed

Verification performed:
- `uv run ruff check examples/` → E402 errors eliminated.
- Notebook integrity check: all code cells compile, and the moved imports are confirmed at the top of their cells.
- JSON validity of both notebooks confirmed.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A — no visual changes.

## Additional Notes

- The remaining `ruff` error (`SIM115` in `examples/openagent_eval_colab_tutorial.ipynb` cell 23) is intentionally left out of scope; issue #313 is scoped to E402 only.
- `uv.lock` was restored (its only change was a `0.4.8 → 0.4.10` version-string bump from `uv sync`) and excluded from this PR.
- The pre-existing `pytest` failures in `tests/unit/test_providers/test_openai.py` are due to missing `openai`/`tiktoken` provider extras in the local environment and are unrelated to this change. Notebook changes are not covered by the unit-test suite.
