### PR TITLE
fix(cli): resolve EvaluationResult annotations in test command

### DIFF
--- a/openagent_eval/cli/commands/test.py
+++ b/openagent_eval/cli/commands/test.py
@@ -11,7 +11,7 @@ from rich.table import Table
 from openagent_eval import __version__
 from openagent_eval.cicd.models import CICDConfig, EvaluationGate, ThresholdConfig
 from openagent_eval.cicd.plugin import OAEvalPlugin
-from openagent_eval.cicd.thresholds import ThresholdEvaluator
+from openagent_eval.cicd.thresholds import EvaluationResult, ThresholdEvaluator
 from openagent_eval.exceptions import ConfigurationError
 
 console = Console()

--- a/tests/unit/test_cicd/test_cli_test.py
+++ b/tests/unit/test_cicd/test_cli_test.py
@@ -3,9 +3,12 @@
 import asyncio
 import json
 import re
+from typing import get_type_hints
 
 from typer.testing import CliRunner
 
+from openagent_eval.cicd.thresholds import EvaluationResult
+from openagent_eval.cli.commands import test as test_command
 from openagent_eval.cli.main import app
 
 runner = CliRunner()
@@ -65,6 +68,23 @@ parallel: false
 
 class TestTestCommand:
     """Tests for oaeval test command."""
+
+    def test_result_annotations_resolve_to_evaluation_result(self):
+        """CLI result helpers resolve their annotations at runtime."""
+        helpers = (test_command._display_results, test_command._output_json)
+        annotations = {}
+        resolution_errors = {}
+
+        for helper in helpers:
+            try:
+                annotations[helper.__name__] = get_type_hints(helper)["result"]
+            except NameError as exc:
+                resolution_errors[helper.__name__] = str(exc)
+
+        assert not resolution_errors, (
+            f"CLI result annotations did not resolve: {resolution_errors}"
+        )
+        assert annotations == {helper.__name__: EvaluationResult for helper in helpers}
 
     def test_test_command_help(self):
         """Test test command help output."""


### PR DESCRIPTION
## Description

Import the canonical `EvaluationResult` type into the CLI test command so the `result` annotations on `_display_results` and `_output_json` resolve at runtime. Add a regression test that resolves both annotations with `typing.get_type_hints` and verifies their identity with `openagent_eval.cicd.thresholds.EvaluationResult`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update
- [ ] CI/CD update

## Related Issues

Fixes #298

## How Has This Been Tested?

- [x] Unit tests pass (`uv run pytest`)
- [ ] Linter passes (`uv run ruff check .`)
- [ ] Type checker passes (`uv run mypy openagent_eval/`)
- [ ] Manual testing performed

- `uv run --no-sync pytest tests/unit/test_cicd/test_cli_test.py::TestTestCommand::test_result_annotations_resolve_to_evaluation_result -q` — 1 passed
- `uv run --no-sync pytest tests/unit/test_cicd/test_cli_test.py -q` — 13 passed
- Changed-file Ruff comparison removed the two in-scope `F821` findings and introduced no new finding; the same pre-existing `B008` and `B904` findings remain on both the base and candidate
- [Fork CI run 32683744794](https://github.com/Nitjsefnie-OSC/openagent-eval/actions/runs/32683744794) passed against `d12158ae8c1d94ffdebba8f3b5b3b4344cb58f75`: Python 3.11 and 3.12 each reported 1082 passed and 4 skipped, and the coverage job reported 1136 passed, 4 skipped, and 82% total coverage

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable; there are no visual changes.

## Additional Notes

No documentation or explanatory comments were needed for this focused import and regression-test change. This PR claims runtime resolution of the two referenced annotations and removal of their `F821` findings; it does not claim a separate change to normal CLI execution behavior.

Generated by GPT-5.6 Sol (brief, review, verification), GPT-5.6 Luna (implementation, testing, verification)
