### PR TITLE
test(cli): verify Rich-wrapped audit error paths

### DIFF
--- a/tests/unit/test_cli/test_audit.py
+++ b/tests/unit/test_cli/test_audit.py
@@ -271,7 +271,10 @@ class TestAuditErrorHandling:
     def test_audit_error_message_includes_path(self, tmp_path):
         missing = tmp_path / "missing_corpus"
         result = runner.invoke(app, ["audit", str(missing)])
-        assert str(missing) in strip_ansi(result.output)
+        path_pattern = r"(?:\r?\n)?".join(
+            re.escape(character) for character in str(missing)
+        )
+        assert re.search(path_pattern, strip_ansi(result.output)) is not None
 
     def test_audit_unknown_check_lists_valid_checks(self, corpus_dir):
         result = runner.invoke(app, ["audit", str(corpus_dir), "--checks", "bogus"])

--- a/tests/unit/test_cli/test_audit.py
+++ b/tests/unit/test_cli/test_audit.py
@@ -281,7 +281,10 @@ class TestAuditErrorHandling:
         path_pattern = r"(?:\r?\n)?".join(
             re.escape(character) for character in str(missing)
         )
-        assert re.search(path_pattern, output) is not None
+        error_path_pattern = (
+            re.escape("Error: Path does not exist: ") + r"(?:\r?\n)?" + path_pattern
+        )
+        assert re.search(error_path_pattern, output) is not None
 
     def test_audit_unknown_check_lists_valid_checks(self, corpus_dir):
         result = runner.invoke(app, ["audit", str(corpus_dir), "--checks", "bogus"])

--- a/tests/unit/test_cli/test_audit.py
+++ b/tests/unit/test_cli/test_audit.py
@@ -7,6 +7,7 @@ import re
 from unittest.mock import ANY, AsyncMock, patch
 
 import pytest
+from rich.console import Console
 from typer.testing import CliRunner
 
 from openagent_eval.cli.context import get_context, reset_context
@@ -269,12 +270,18 @@ class TestAuditErrorHandling:
     """Tests for error handling on non-existent or invalid corpus paths."""
 
     def test_audit_error_message_includes_path(self, tmp_path):
-        missing = tmp_path / "missing_corpus"
-        result = runner.invoke(app, ["audit", str(missing)])
+        missing = tmp_path / ("missing_corpus_" + "x" * 64)
+        with patch(
+            "openagent_eval.cli.commands.audit.console",
+            Console(width=40, force_terminal=False),
+        ):
+            result = runner.invoke(app, ["audit", str(missing)], terminal_width=40)
+        output = strip_ansi(result.output)
+        assert str(missing) not in output
         path_pattern = r"(?:\r?\n)?".join(
             re.escape(character) for character in str(missing)
         )
-        assert re.search(path_pattern, strip_ansi(result.output)) is not None
+        assert re.search(path_pattern, output) is not None
 
     def test_audit_unknown_check_lists_valid_checks(self, corpus_dir):
         result = runner.invoke(app, ["audit", str(corpus_dir), "--checks", "bogus"])


### PR DESCRIPTION
## Description

Updates the existing audit missing-path test to deterministically exercise Rich line wrapping through the real CLI path. The assertion now requires the exact path at the missing-path error occurrence while allowing only LF or CRLF line breaks introduced by wrapping.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update
- [ ] CI/CD update

## Related Issues

Closes #302

## How Has This Been Tested?

- Focused regression: `1 passed`
- Audit test module: `24 passed`
- Changed-file Ruff lint and format checks passed for `tests/unit/test_cli/test_audit.py`
- [Exact-SHA fork CI](https://github.com/Nitjsefnie-OSC/openagent-eval/actions/runs/32685540443) succeeded in all three jobs and logged candidate `363ec48ea68f9117779fe49c3dc69aa8c75fe32e`: Python 3.11 and 3.12 each reported 1081 passed and 4 skipped; coverage reported 1135 passed, 4 skipped, and 82.26%

- [x] Unit tests pass (`uv run pytest`)
- [ ] Linter passes (`uv run ruff check .`)
- [ ] Type checker passes (`uv run mypy openagent_eval/`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (not applicable; no production logic was added)
- [ ] I have made corresponding changes to the documentation (not applicable; test-only change)
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (verified in exact-SHA fork CI instead)

## Screenshots (if applicable)

Not applicable; this is a test-only change.

## Additional Notes

No production code or dependencies changed.

Generated by GPT-5.6 Sol (brief, review, verification), GPT-5.6 Luna (implementation, testing, verification)
