### PR TITLE
fix(cli): render unexpected exception diagnostics literally

### DIFF
--- a/openagent_eval/cli/main.py
+++ b/openagent_eval/cli/main.py
@@ -7,7 +7,7 @@ from importlib.metadata import PackageNotFoundError, version
 
 import typer
 from rich.console import Console
-from rich.markup import escape
+from rich.text import Text
 from typer.core import TyperGroup
 
 from openagent_eval.cli.banner import create_mini_banner
@@ -500,7 +500,7 @@ def _cli_exception_handler(
     else:
         # For unexpected errors, show a user-friendly message
         console = Console(stderr=True)
-        console.print(f"\n[red]Unexpected error:[/red] {escape(str(exc_value))}")
+        console.print(Text.assemble(("\nUnexpected error:", "red"), f" {exc_value}"))
         console.print("[dim]This is a bug. Please report it at:[/dim]")
         console.print(
             "  [dim]https://github.com/OpenAgentHQ/openagent-eval/issues[/dim]"

--- a/openagent_eval/cli/main.py
+++ b/openagent_eval/cli/main.py
@@ -500,8 +500,8 @@ def _cli_exception_handler(
         # For unexpected errors, show a user-friendly message
         console = Console(stderr=True)
         console.print(f"\n[red]Unexpected error:[/red] {exc_value}")
-        console.print("[dim]This is a bug. Please report it at:")
-        console.print("  https://github.com/OpenAgentHQ/openagent-eval/issues[/dim]")
+        console.print("[dim]This is a bug. Please report it at:[/dim]")
+        console.print("  [dim]https://github.com/OpenAgentHQ/openagent-eval/issues[/dim]")
         raise typer.Exit(code=1) from None
 
 

--- a/openagent_eval/cli/main.py
+++ b/openagent_eval/cli/main.py
@@ -7,6 +7,7 @@ from importlib.metadata import PackageNotFoundError, version
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 from typer.core import TyperGroup
 
 from openagent_eval.cli.banner import create_mini_banner
@@ -499,9 +500,11 @@ def _cli_exception_handler(
     else:
         # For unexpected errors, show a user-friendly message
         console = Console(stderr=True)
-        console.print(f"\n[red]Unexpected error:[/red] {exc_value}")
+        console.print(f"\n[red]Unexpected error:[/red] {escape(str(exc_value))}")
         console.print("[dim]This is a bug. Please report it at:[/dim]")
-        console.print("  [dim]https://github.com/OpenAgentHQ/openagent-eval/issues[/dim]")
+        console.print(
+            "  [dim]https://github.com/OpenAgentHQ/openagent-eval/issues[/dim]"
+        )
         raise typer.Exit(code=1) from None
 
 

--- a/tests/unit/test_cli/test_main.py
+++ b/tests/unit/test_cli/test_main.py
@@ -96,20 +96,26 @@ def test_cli_invalid_command():
     assert result.exit_code != 0
 
 
-def test_unexpected_cli_exception_preserves_diagnostic_and_exit_code(monkeypatch):
-    """Unexpected errors render their diagnostic and exit through Typer."""
+@pytest.mark.parametrize(
+    "message",
+    ["boom", "dynamic [bold] text", "dynamic [/dim] text"],
+)
+def test_unexpected_cli_exception_preserves_diagnostic_and_exit_code(
+    monkeypatch, message
+):
+    """Unexpected errors render arbitrary diagnostics and exit through Typer."""
     output = StringIO()
     console = Console(file=output, force_terminal=False, color_system=None)
     monkeypatch.setattr(main, "Console", lambda **kwargs: console)
 
     with pytest.raises(BaseException) as exc_info:
-        main._cli_exception_handler(RuntimeError, RuntimeError("boom"), None)
+        main._cli_exception_handler(RuntimeError, RuntimeError(message), None)
 
     assert isinstance(exc_info.value, typer.Exit)
     assert exc_info.value.exit_code == 1
     rendered = output.getvalue()
     assert "Unexpected error" in rendered
-    assert "boom" in rendered
+    assert message in rendered
     assert "https://github.com/OpenAgentHQ/openagent-eval/issues" in rendered
 
 

--- a/tests/unit/test_cli/test_main.py
+++ b/tests/unit/test_cli/test_main.py
@@ -98,7 +98,15 @@ def test_cli_invalid_command():
 
 @pytest.mark.parametrize(
     "message",
-    ["boom", "dynamic [bold] text", "dynamic [/dim] text"],
+    [
+        "boom",
+        "dynamic [bold] text",
+        "dynamic [/dim] text",
+        "[bold][italic]nested[/italic][/bold]",
+        "[bold]unmatched",
+        r"\[",
+        r"slashes \\\\ [bold] " + r"\\\\",
+    ],
 )
 def test_unexpected_cli_exception_preserves_diagnostic_and_exit_code(
     monkeypatch, message

--- a/tests/unit/test_cli/test_main.py
+++ b/tests/unit/test_cli/test_main.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+from io import StringIO
+
+import pytest
+import typer
+from rich.console import Console
 from typer.testing import CliRunner
 
+from openagent_eval.cli import main
 from openagent_eval.cli.main import app
 
 runner = CliRunner()
@@ -88,6 +94,23 @@ def test_cli_invalid_command():
     """Test that CLI handles invalid commands gracefully."""
     result = runner.invoke(app, ["invalid-command"])
     assert result.exit_code != 0
+
+
+def test_unexpected_cli_exception_preserves_diagnostic_and_exit_code(monkeypatch):
+    """Unexpected errors render their diagnostic and exit through Typer."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, color_system=None)
+    monkeypatch.setattr(main, "Console", lambda **kwargs: console)
+
+    with pytest.raises(BaseException) as exc_info:
+        main._cli_exception_handler(RuntimeError, RuntimeError("boom"), None)
+
+    assert isinstance(exc_info.value, typer.Exit)
+    assert exc_info.value.exit_code == 1
+    rendered = output.getvalue()
+    assert "Unexpected error" in rendered
+    assert "boom" in rendered
+    assert "https://github.com/OpenAgentHQ/openagent-eval/issues" in rendered
 
 
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Description

Fix unexpected CLI error reporting so Rich renders the original exception diagnostic, report instruction, and issue URL without raising a secondary markup error. The dynamic exception message is appended through a literal `Text.assemble` boundary while styling remains limited to static text, preserving Rich-looking and backslash-heavy diagnostics exactly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update
- [ ] CI/CD update

## Related Issues

Fixes #299

## How Has This Been Tested?

- [x] Unit tests pass (`uv run pytest`)
- [ ] Linter passes (`uv run ruff check .`)
- [ ] Type checker passes (`uv run mypy openagent_eval/`)
- [ ] Manual testing performed

- `.venv/bin/pytest tests/unit/test_cli/test_main.py::test_unexpected_cli_exception_preserves_diagnostic_and_exit_code -q` — 7 passed
- `.venv/bin/pytest tests/unit/test_cli/test_main.py -q` — 18 passed
- `.venv/bin/ruff check openagent_eval/cli/main.py tests/unit/test_cli/test_main.py` — all changed-file checks passed
- `.venv/bin/ruff format --check openagent_eval/cli/main.py tests/unit/test_cli/test_main.py` — both changed files already formatted
- [Fork CI run 32685472708](https://github.com/Nitjsefnie-OSC/openagent-eval/actions/runs/32685472708) passed against `63fe51f92f657c6a14afa41cde00b6128bbc3d39`: Python 3.11 and 3.12 each reported 1088 passed and 4 skipped, and the coverage job reported 1142 passed, 4 skipped, and 82% total coverage; all three jobs succeeded and logged the exact candidate SHA

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable; there are no visual changes.

## Additional Notes

No documentation or explanatory comments were needed for this focused exception-rendering change. Repository-wide Ruff and mypy were not run locally; the lint and format results above are limited to the changed files, while the full test matrix ran in fork CI on the exact candidate SHA.

Generated by GPT-5.6 Sol (brief, review, verification), GPT-5.6 Luna (implementation, testing, verification)
