### PR TITLE
fix(examples): close Colab tutorial data file

### DIFF
--- a/examples/openagent_eval_colab_tutorial.ipynb
+++ b/examples/openagent_eval_colab_tutorial.ipynb
@@ -766,7 +766,8 @@
    "source": [
     "import json\n",
     "\n",
-    "cases = json.load(open(\"data.json\"))\n",
+    "with open(\"data.json\") as f:\n",
+    "    cases = json.load(f)\n",
     "print(f\"Loaded {len(cases)} test cases.\")\n",
     "print(\"First question:\", cases[0][\"question\"])"
    ]

--- a/tests/unit/test_examples/test_colab_tutorial.py
+++ b/tests/unit/test_examples/test_colab_tutorial.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+
+NOTEBOOK = (
+    Path(__file__).parents[3] / "examples" / "openagent_eval_colab_tutorial.ipynb"
+)
+
+
+def _data_loading_cell_source() -> str:
+    notebook = json.loads(NOTEBOOK.read_text(encoding="utf-8"))
+    for cell in notebook["cells"]:
+        if cell.get("id") == "a0e2944d":
+            return "".join(cell["source"])
+    raise AssertionError("data-loading cell not found")
+
+
+def test_colab_data_loading_closes_json_file():
+    source = _data_loading_cell_source()
+
+    assert 'cases = json.load(open("data.json"))' not in source
+    assert 'with open("data.json") as f:' in source
+    assert "cases = json.load(f)" in source


### PR DESCRIPTION
## Description

This PR fixes the SIM115 violation in the Colab tutorial by opening `data.json` with a context manager before loading it. The executed cell's behavior and notebook metadata/outputs remain unchanged, and a focused regression test protects the pattern.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update
- [ ] CI/CD update

## Related Issues

Fixes #312

## How Has This Been Tested?

Focused local checks and an offline execution of the affected notebook cell were run. The fork's `osc-manual.yml` wrapper also ran its unit-test matrix and coverage job on the exact candidate SHA.

- [ ] Unit tests pass (`uv run pytest`) — the full local suite was not run; fork CI ran `uv run pytest tests/unit -v --tb=short` successfully.
- [ ] Linter passes (`uv run ruff check .`) — the full repository lint backlog is not claimed; changed-file Ruff and `SIM115` checks passed.
- [ ] Type checker passes (`uv run mypy openagent_eval/`) — no package source changed.
- [x] Manual testing performed — the affected cell loaded temporary offline JSON and preserved its expected output.

Focused results:

- `python3 -m pytest tests/unit/test_examples/test_colab_tutorial.py -q` — 1 passed.
- `uv run --no-sync ruff check tests/unit/test_examples/test_colab_tutorial.py examples/openagent_eval_colab_tutorial.ipynb` — all checks passed.
- `uv run --no-sync ruff check --select SIM115 examples/openagent_eval_colab_tutorial.ipynb` — all checks passed.
- Notebook JSON validity and `git diff --check` — passed.
- Fork CI run `32885800403`: Python 3.11 and 3.12 unit-test jobs plus Coverage all succeeded.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — no new non-obvious production logic was added.
- [ ] I have made corresponding changes to the documentation — the affected tutorial notebook is the documentation change.
- [x] My changes generate no new warnings — focused checks were clean; CI warnings were pre-existing runner/dependency warnings.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes — the focused test passed locally; the broader unit suite passed in fork CI.

## Screenshots (if applicable)

N/A — no visual changes.

## Additional Notes

- The candidate changes only `examples/openagent_eval_colab_tutorial.ipynb` and `tests/unit/test_examples/test_colab_tutorial.py`.
- The notebook diff changes only the data-loading source lines; cell metadata, execution count, outputs, and unrelated content were preserved.
- Fork CI run `32885800403` checked out `c18802e1e1052f1634af8182a1725be53e535f15` in both a matrix test job and Coverage; Coverage reported 1152 passed, 4 skipped, and 82.35% coverage against a 75% threshold.

Generated by GPT-5.6 Luna (implementation, testing), GPT-5.6 Sol (brief, review, verification)
