### PR TITLE
test(exceptions): rename FalsyException to FalsyError

### DIFF
--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -31,7 +31,7 @@ from openagent_eval.exceptions import (
 )
 
 
-class FalsyException(Exception):
+class FalsyError(Exception):
     """Exception whose truthiness is false despite being an exception."""
 
     def __bool__(self) -> bool:
@@ -366,7 +366,7 @@ class TestFalsyDetailRecording:
         assert "original_error" in error.details
 
     def test_corpus_audit_error_preserves_falsy_original_error(self) -> None:
-        original_error = FalsyException("boom")
+        original_error = FalsyError("boom")
         error = CorpusAuditError("Audit failed", original_error=original_error)
         assert "original_error" in error.details
         assert error.original_error is original_error
@@ -425,7 +425,7 @@ class TestFalsyDetailRecording:
         assert "original_error" in error.details
 
     def test_metric_execution_error_preserves_falsy_original_error(self) -> None:
-        original_error = FalsyException("boom")
+        original_error = FalsyError("boom")
         error = MetricExecutionError("Failed", original_error=original_error)
         assert "original_error" in error.details
         assert error.original_error is original_error
@@ -457,7 +457,7 @@ class TestFalsyDetailRecording:
         assert "original_error" in error.details
 
     def test_plugin_load_error_preserves_falsy_original_error(self) -> None:
-        original_error = FalsyException("boom")
+        original_error = FalsyError("boom")
         error = PluginLoadError("Failed to load", original_error=original_error)
         assert "original_error" in error.details
         assert error.original_error is original_error
@@ -491,7 +491,7 @@ class TestFalsyDetailRecording:
         assert "original_error" in error.details
 
     def test_provider_connection_error_preserves_falsy_original_error(self) -> None:
-        original_error = FalsyException("boom")
+        original_error = FalsyError("boom")
         error = ProviderConnectionError(
             "Failed to connect", original_error=original_error
         )
@@ -509,7 +509,7 @@ class TestFalsyDetailRecording:
         assert "original_error" in error.details
 
     def test_provider_execution_error_preserves_falsy_original_error(self) -> None:
-        original_error = FalsyException("boom")
+        original_error = FalsyError("boom")
         error = ProviderExecutionError("API call failed", original_error=original_error)
         assert "original_error" in error.details
         assert error.original_error is original_error
@@ -527,7 +527,7 @@ class TestFalsyDetailRecording:
         assert "original_error" in error.details
 
     def test_synthesis_execution_error_preserves_falsy_original_error(self) -> None:
-        original_error = FalsyException("boom")
+        original_error = FalsyError("boom")
         error = SynthesisExecutionError(
             "Synthesis failed", original_error=original_error
         )


### PR DESCRIPTION
## Description

Renames the test-only `FalsyException` helper and its six call sites to `FalsyError`, satisfying Ruff N818 without changing the falsy-exception behavior those tests exercise.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update
- [ ] CI/CD update

## Related Issues

Closes #309

## How Has This Been Tested?

- `uv run ruff check tests/unit/test_exceptions.py`
- `uv run pytest tests/unit/test_exceptions.py` — 78 passed
- Fork CI run 32887146912 — Python 3.11, Python 3.12, and coverage jobs passed on candidate `3adca166026efdf65a641f1a07daf2a877df1348`

- [x] Unit tests pass (`uv run pytest`)
- [ ] Linter passes (`uv run ruff check .`)
- [ ] Type checker passes (`uv run mypy openagent_eval/`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The repository-wide lint command still reports pre-existing findings outside this one-file change, so the full-linter checkbox remains unchecked. The changed file passes the project-locked Ruff invocation.

---

Generated by Kimi K3 (implementation, adversarial review)
