### PR TITLE
docs: add offline testing workflow

### DIFF
--- a/docs/providers/llm/mock.md
+++ b/docs/providers/llm/mock.md
@@ -81,5 +81,7 @@ print(report.summary["metrics_summary"])
 
 ## Related
 
+- Follow the [offline testing guide](../../testing-offline.md) for a complete
+  CLI, Python, and CI workflow.
 - Pair with the [mock retriever](../retrievers/mock.md) for a 100% offline run.
 - See all LLMs in [index.md](index.md).

--- a/docs/providers/retrievers/mock.md
+++ b/docs/providers/retrievers/mock.md
@@ -74,6 +74,8 @@ print(report.summary["metrics_summary"])
 
 ## Related
 
+- Follow the [offline testing guide](../../testing-offline.md) for a complete
+  CLI, Python, and CI workflow.
 - Ready to go live? Switch to [Chroma](chroma.md) or any other vector
   store and update `retriever.provider`.
 - Pair with an LLM from [../llm/index.md](../llm/index.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -82,6 +82,12 @@ This checks:
 - Dataset file existence
 - Output directory accessibility
 
+!!! tip "Test without API keys"
+    Use the built-in mock LLM and retriever to run the complete pipeline without
+    credentials, network access, or a vector database. Follow the
+    [offline testing guide](testing-offline.md) for a ready-to-run fixture and
+    configuration.
+
 ## 3. Prepare a dataset
 
 OpenAgent Eval loads datasets in **JSON**, **JSONL**, **CSV**, or **PDF** format. Each item needs a
@@ -203,6 +209,7 @@ assert report.summary["metrics_summary"]["faithfulness"] >= 0.8
 
 ## Next steps
 
+- Add an API-key-free smoke test with the [offline testing guide](testing-offline.md).
 - Understand the internals on the [Architecture](architecture.md) page.
 - Learn every flag in the [CLI Reference](cli.md).
 - Discover the full API in [API Reference](api.md).

--- a/docs/testing-offline.md
+++ b/docs/testing-offline.md
@@ -1,0 +1,149 @@
+# Testing Offline
+
+OpenAgent Eval includes deterministic mock LLM and retriever providers. Use
+them to exercise configuration loading, dataset ingestion, metrics, and report
+generation without API keys, network calls, or a vector database.
+
+This mode is useful for:
+
+- checking a new installation before configuring credentials;
+- running fast smoke tests in CI;
+- developing report and metric integrations locally;
+- learning the evaluation workflow without incurring provider costs.
+
+Mock scores only prove that the evaluation pipeline works. They do not measure
+the quality of a production model or retriever.
+
+## Run an offline evaluation
+
+Create a small dataset whose rows include both `ground_truth` and
+`ground_truth_contexts`:
+
+```json title="data/offline-smoke.json"
+[
+  {
+    "question": "What does RAG combine?",
+    "ground_truth": "RAG combines retrieval with generation.",
+    "ground_truth_contexts": [
+      "Retrieval-Augmented Generation combines retrieval with generation."
+    ]
+  }
+]
+```
+
+Configure both mock providers:
+
+```yaml title="offline.yaml"
+dataset:
+  path: data/offline-smoke.json
+
+llm:
+  provider: mock
+  model: mock-model
+
+retriever:
+  provider: mock
+
+metrics:
+  retrieval:
+    - context_precision
+    - context_recall
+  generation:
+    - exact_match
+  performance:
+    - latency
+
+report:
+  output: terminal
+  output_dir: ./reports
+```
+
+Validate and run it with no provider environment variables set:
+
+```bash
+oaeval validate offline.yaml
+oaeval run offline.yaml
+```
+
+The mock LLM returns each row's `ground_truth`. The mock retriever returns its
+`ground_truth_contexts` as retrieved documents. Exact-match and retrieval
+scores should therefore be perfect for this fixture; that is an assertion
+about the harness, not a quality benchmark.
+
+## Use it from Python
+
+The same path can be embedded in a test without loading a configuration file:
+
+```python title="test_offline_eval.py"
+import asyncio
+
+from openagent_eval.config.models import Config
+from openagent_eval.core.engine import Engine
+
+
+def test_evaluation_pipeline_offline() -> None:
+    config = Config(
+        dataset={"path": "data/offline-smoke.json"},
+        llm={"provider": "mock", "model": "mock-model"},
+        retriever={"provider": "mock"},
+        metrics={
+            "retrieval": ["context_precision", "context_recall"],
+            "generation": ["exact_match"],
+        },
+    )
+    dataset = [
+        {
+            "question": "What does RAG combine?",
+            "ground_truth": "RAG combines retrieval with generation.",
+            "ground_truth_contexts": [
+                "Retrieval-Augmented Generation combines retrieval with generation."
+            ],
+        }
+    ]
+
+    engine = Engine(config)
+    try:
+        report = asyncio.run(engine.run(dataset))
+    finally:
+        engine.shutdown()
+
+    assert report.summary["failed_evaluations"] == 0
+    assert report.summary["metrics_summary"]["exact_match"] == 1.0
+```
+
+## Add a CI smoke test
+
+Keep the offline dataset and configuration in the repository, then run the
+same commands after installing the package:
+
+```yaml title=".github/workflows/eval-smoke.yml"
+name: Evaluation smoke test
+
+on:
+  pull_request:
+
+jobs:
+  offline-eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install openagent-eval
+      - run: oaeval validate offline.yaml
+      - run: oaeval run offline.yaml
+```
+
+No secrets are required for this job. Keep the fixture small so it remains a
+fast pipeline check, and run real-provider evaluations separately when model or
+retrieval quality is the subject under test.
+
+## Move to real providers
+
+When the offline path is green, replace one mock at a time. Point `llm.provider`
+at a supported model provider to evaluate generation, or replace
+`retriever.provider` to evaluate a real retrieval system. See the
+[Mock LLM](providers/llm/mock.md) and
+[Mock retriever](providers/retrievers/mock.md) pages for provider behavior and
+configuration details.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
   - Getting Started:
       - Installation: installation.md
       - Quickstart: quickstart.md
+      - Testing Offline: testing-offline.md
   - Providers:
       - providers/index.md
       - LLM:


### PR DESCRIPTION
## Summary
- add a first-class offline testing guide with complete dataset and configuration fixtures
- document CLI, Python SDK, and GitHub Actions workflows using the built-in mock LLM and retriever
- add the guide to MkDocs navigation and cross-link it from Quickstart and both mock provider pages

Closes #334

## Verification
- `uv run --with mkdocs-material mkdocs build --strict`
- executed the documented Python mock-provider flow locally; all metrics completed and `exact_match`, `context_precision`, and `context_recall` were 1.0
- `git diff --check`

## Repository baseline
- `uv run ruff check .` currently reports 20 pre-existing Python lint errors in files untouched by this documentation-only change.