### PR TITLE
docs(readme): add zero-key quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,45 @@ uv sync
 
 ---
 
+## Try It in 60 Seconds — No API Key Needed
+
+The built-in mock providers run a complete evaluation locally, without network calls or credentials. Copy and paste this block after installing `openagent-eval`:
+
+```bash
+cat > quickstart-dataset.json <<'JSON'
+[
+  {
+    "question": "What is retrieval-augmented generation?",
+    "ground_truth": "RAG combines retrieval with generation.",
+    "ground_truth_contexts": ["RAG combines retrieval with generation."]
+  }
+]
+JSON
+
+cat > quickstart.yaml <<'YAML'
+dataset:
+  path: quickstart-dataset.json
+llm:
+  provider: mock
+  model: mock-model
+retriever:
+  provider: mock
+metrics:
+  retrieval: [context_precision]
+  generation: [exact_match]
+  performance: [latency]
+  cost: [token_count]
+report:
+  output: terminal
+YAML
+
+oaeval run quickstart.yaml
+```
+
+This uses deterministic offline stand-ins so you can verify the full dataset → retrieval → generation → metrics → report flow before configuring a real model or vector store.
+
+---
+
 ## Quick Start
 
 ### 1. Initialize Configuration


### PR DESCRIPTION
## Summary

- add a copy-pasteable offline quickstart immediately after installation
- use the built-in mock LLM and retriever with a minimal dataset
- show the full dataset → retrieval → generation → metrics → report path before API-key setup

## Verification

- copied the documented files into a clean directory
- `oaeval validate quickstart.yaml` passed with no API keys
- `oaeval run quickstart.yaml` completed with 1 item and 0 errors
- `uv run pytest tests/integration/test_pipeline/test_mock_e2e.py` (3 passed)

Repository-wide Ruff, mypy, and pytest currently fail on pre-existing main-branch issues (36 lint errors, 163 type errors, and missing `numpy` during test collection); this README-only change does not touch those paths.

Closes #331

Implementation and validation were assisted by OpenAI Codex; I reviewed the final documentation and executed the snippet end-to-end.