### PR TITLE
fix(pgvector): resolve F401 unused import for psycopg

### DIFF
--- a/openagent_eval/providers/retrievers/pgvector.py
+++ b/openagent_eval/providers/retrievers/pgvector.py
@@ -7,6 +7,7 @@ similarity. Documents/queries are embedded locally with the configured
 
 from __future__ import annotations
 
+import importlib.util
 from typing import TYPE_CHECKING, Any
 
 from openagent_eval.exceptions.provider import (
@@ -60,12 +61,15 @@ class PGVectorRetriever(Retriever):
         self._conn: Any = None
 
         try:
-            import psycopg
-        except ImportError as exc:  # pragma: no cover - depends on installed dep
-            raise ImportError(
-                "psycopg + pgvector are required for the pgvector retriever. "
-                "Install it with: pip install openagent-eval[pgvector]"
-            ) from exc
+            if importlib.util.find_spec("psycopg") is None:  # pragma: no cover - depends on installed dep
+                raise ImportError(
+                    "psycopg + pgvector are required for the pgvector retriever. "
+                    "Install it with: pip install openagent-eval[pgvector]"
+                )
+        except ValueError:  # pragma: no cover - mocked module in tests
+            # importlib.util.find_spec raises ValueError for mocked modules
+            # (e.g., in tests where psycopg is patched into sys.modules)
+            pass
 
     async def _ensure_connection(self) -> None:
         """Lazily open the async Postgres connection on first use.


### PR DESCRIPTION
## Summary

Fixes F401 lint error in `pgvector.py` where `psycopg` was imported but unused.

## Changes

- Replace direct `import psycopg` with `importlib.util.find_spec("psycopg")` check (ruff's recommended approach for F401)
- Add `ValueError` handling for mocked modules in tests (where `psycopg` is patched into `sys.modules`)

## Testing

- `ruff check openagent_eval/providers/retrievers/pgvector.py` - All checks pass
- `pytest tests/unit/test_providers/test_pgvector_retriever.py -v` - All 4 tests pass

## Related

Fixes #306