### PR TITLE
docs(ci): document mypy strict mode target and current CI status #339

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -173,7 +173,9 @@ uv run ruff check --fix .
 
 ### Type Checking
 
-This project uses [mypy](https://mypy.readthedocs.io/) for static type checking.
+This project uses [mypy](https://mypy.readthedocs.io/) for static type checking and is configured with `strict = true` in `pyproject.toml`.
+
+**Note on CI Enforcement:** Currently, mypy strict mode is non-blocking in our CI pipeline (`continue-on-error: true`). While type-checking errors will not immediately fail your build, we are actively working towards making strict type enforcement a blocking requirement. Contributors are highly encouraged to resolve all mypy errors locally before submitting a PR to help us reach this target. (For more details, see the related CI-enforcement tracking issue: [#344](https://github.com/OpenAgentHQ/openagent-eval/issues/344)).
 
 ```bash
 uv run mypy openagent_eval/


### PR DESCRIPTION
## Description

Updates `DEVELOPMENT.md` to clarify the current state of `mypy` type checking in the project. It notes that while `mypy` is configured with `strict = true`, it is currently non-blocking in the CI pipeline. It also directs contributors to resolve type errors locally and links to the tracking issue (#344) for making it a blocking requirement in the future.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] CI/CD update

## Related Issues

Closes #339 

## How Has This Been Tested?

As this is a documentation-only change, I reviewed the Markdown formatting locally to ensure it renders correctly.

- [ ] Unit tests pass (`uv run pytest`)
- [ ] Linter passes (`uv run ruff check .`)
- [ ] Type checker passes (`uv run mypy openagent_eval/`)
- [x] Manual testing performed (Markdown formatting review)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A

## Additional Notes

Added the link to the tracking issue #344 directly in the documentation as requested.