### PR TITLE
chore: bump openagent-eval version to 0.4.10 in lockfile

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2466,7 +2466,7 @@ wheels = [
 
 [[package]]
 name = "openagent-eval"
-version = "0.4.8"
+version = "0.4.10"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Updates `uv.lock` to reflect the `openagent-eval` package version bump from `0.4.8` to `0.4.10`

## Test plan
- [ ] Verify CI passes with the updated lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kh4copjxvpDJU4zs9tDrgh